### PR TITLE
Add support for overriding config.reportDir with an environment variable

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -6,7 +6,7 @@ var config = {
 
 // Base Directories
 config.libDir         = __dirname;
-config.reportDir      = path.join(process.cwd(), 'mochawesome-reports');
+config.reportDir      = path.join(process.cwd(), process.env.AWESOME_DIR || 'mochawesome-reports');
 config.nodeModulesDir = path.join(__dirname, '..', 'node_modules');
 
 // Build Directories


### PR DESCRIPTION
The config.reportDir may need to be overridable. If the environment variable AWESOME_DIR is defined, then use that, else default to "mochawesome-reports" for the report directory.