### PR TITLE
Reset total test counter in reporter init

### DIFF
--- a/lib/mochawesome.js
+++ b/lib/mochawesome.js
@@ -30,6 +30,9 @@ module.exports = Mochawesome;
  */
 
 function Mochawesome (runner, options) {
+  // reset total tests counter
+  totalTestsRegistered = 0;
+
   // Create/Save necessary report dirs/files
   var reporterOpts = options.reporterOptions || {},
       config = conf(reporterOpts);


### PR DESCRIPTION
When using mochawesome multiple times in one process - for example tests are executed on web server, then total tests counter is not reseted before each run. First run has correct count of tests, but second round is starting when previous ended - which means statistic is broken.

I am a newbie in forks and pull requests, maybe something important is missing now..