### PR TITLE
Feature/fix empty code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@ mochawesome
 ===========
 [![npm](https://img.shields.io/npm/v/mochawesome.svg?style=flat-square)](http://www.npmjs.com/package/mochawesome) [![Build Status](https://img.shields.io/travis/adamgruber/mochawesome/master.svg?style=flat-square)](https://travis-ci.org/adamgruber/mochawesome) [![Code Climate](https://img.shields.io/codeclimate/github/adamgruber/mochawesome.svg?style=flat-square)](https://codeclimate.com/github/adamgruber/mochawesome)
 
-Mochawesome is a custom reporter for use with the Javascript testing framework, [mocha](http://visionmedia.github.io/mocha/). It generates a full fledged HTML/CSS report that helps visualize your test suites.
+Mochawesome is a custom reporter for use with the Javascript testing framework, [mocha][1]. It generates a full fledged HTML/CSS report that helps visualize your test suites.
 
-##New in 1.2.2
-- New [Options](#options):
-  - change the report title in the output
-  - generate report with assets inlined
+##New in 1.3.0
+- Changes to support [mocha][1] v2.4.0 and later
 
 ##Features
 - At-a-glance stats including pass percentage
@@ -87,7 +85,12 @@ The two main files to be aware of are:
 ##Options
 Mochawesome supports options via environment variables or passed in to mocha via `--reporter-options`.
 
-With options you can specify the location where reports are saved, the filename of the report and the title of the report in the html output. *Setting a custom filename will change both the report html and json files.*
+- `reportDir: {String}` - changes the name of the report directory
+- `reportName: {String}` - changes the name of the report file
+- `reportTitle: {Sring}` - changes the title of the report
+- `inlineAssets: {Boolean}` - when `true` inlines all report assets into a self-contained report file
+
+*Setting a custom filename will change both the report html and json files.*
 
 **Options passed in will take precedence over environment variables.**
 
@@ -148,3 +151,5 @@ After building you can run this to test the reporter and see the output.
 
 ####`gulp testOpts` - Run Test with Options
 After building you can run this to test the reporter and see the output.
+
+[1]: http://visionmedia.github.io/mocha/

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 #Changelog
 
+###1.3.0
+- Changes to support mocha 2.4.0 and later (fixes empty code blocks). See [#29](https://github.com/adamgruber/mochawesome/issues/29)
+
 ###1.2.2
 - Added option to generate report with all assets inlined. See [#26](https://github.com/adamgruber/mochawesome/issues/26)
 

--- a/lib/mochawesome.js
+++ b/lib/mochawesome.js
@@ -240,14 +240,15 @@ function cleanSuite (suite) {
  */
 
 function cleanTest (test) {
-  var code = '',
+  var code = test.fn ? test.fn.toString() : test.body,
       err = test.err ? _.pick( test.err, ['name', 'message', 'stack'] ) : test.err;
-  if(test.fn){
-    code = cleanCode(test.fn.toString());
+
+  if (code) {
+    code = cleanCode(code);
     code = Highlight.fixMarkup(Highlight.highlightAuto(code).value);
   }
 
-  if(err && err.stack){
+  if (err && err.stack) {
     err.stack = Highlight.fixMarkup(Highlight.highlightAuto(err.stack).value);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mochawesome",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "A Gorgeous HTML/CSS Reporter for Mocha.js",
   "scripts": {
     "test": "gulp build"


### PR DESCRIPTION
Fixes https://github.com/adamgruber/mochawesome/issues/29

mocha v2.4.0 made changes to the `test` object changing the `fn` property which held the test function to `body` which now has the test function as a string. mochawesome will now support both cases.