### PR TITLE
do exit when generateReport finished the file copy

### DIFF
--- a/lib/mochawesome.js
+++ b/lib/mochawesome.js
@@ -46,7 +46,7 @@ function Mochawesome (runner, options) {
   var runnerPromise = new Promise(function (resolve) {
     self.done = function (failures, fn) {
       resolve(function () {
-        fn && fn(failures);
+        if(fn) fn(failures);
       });
     };
   });

--- a/lib/mochawesome.js
+++ b/lib/mochawesome.js
@@ -40,6 +40,26 @@ function Mochawesome (runner, options) {
   generateReport(config);
 
   var self = this;
+
+  // Listen for finish
+  var runnerPromise = new Promise(function (resolve) {
+    self.done = function (failures, fn) {
+      resolve(function () {
+        fn && fn(failures);
+      });
+    };
+  });
+
+  var reportPromise = new Promise(function (resolve) {
+    generateReport(config, function () {
+      resolve();
+    });
+  });
+  Promise.all([runnerPromise, reportPromise]).then(function (resaults) {
+    var runnerCallBack = resaults[0];
+    runnerCallBack();
+  });
+
   Base.call(self, runner);
 
   // Show the Spec Reporter in the console

--- a/lib/mochawesome.js
+++ b/lib/mochawesome.js
@@ -42,6 +42,7 @@ function Mochawesome (runner, options) {
   var self = this;
 
   // Listen for finish
+  var Promise = require('es6-promise').Promise;
   var runnerPromise = new Promise(function (resolve) {
     self.done = function (failures, fn) {
       resolve(function () {

--- a/lib/reportGenerator.js
+++ b/lib/reportGenerator.js
@@ -8,7 +8,7 @@ var async  = require('async'),
 exports.generateReport = generateReport;
 exports.saveToFile = saveToFile;
 
-function generateReport (config) {
+function generateReport (config, callback) {
   console.log('[' + chalk.gray('mochawesome') + '] Generating report files...\n');
   if (config.inlineAssets) {
     return createDirs(config, true, _.noop);
@@ -35,6 +35,7 @@ function generateReport (config) {
         copyFonts(config, callback);
       }]
   }, function(err, results) {
+      if(callback) callback();
       if (err) throw err;
       // console.log('err = ', err);
       // console.log('results = ', results);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "chalk": "^1.0.0",
+    "es6-promise": "^3.1.2",
     "handlebars": "^3.0.3",
     "highlight.js": "^8.5.0",
     "json-stringify-safe": "^5.0.0",


### PR DESCRIPTION
In mocha there call the exit when process finished:

``` javascript
  function done(failures) {
    if (reporter.done) {
      reporter.done(failures, fn);
    } else {
      fn && fn(failures);
    }
  }

  return runner.run(done);
```

And in mochawesome, `reportGenerator` use `async.auto` to copy the resource files. When mocha finish the test and call function `done`, mochawesome do not provide the function `reporter.done` and mocha will run `fn` directly.

`fn` ref:

``` javascript
runner = mocha.run(program.exit ? exit : exitLater);
...
function exitLater(code) {
  process.on('exit', function() { process.exit(code) })
}

function exit(code) {
  // flush output for Node.js Windows pipe bug
  // https://github.com/joyent/node/issues/6247 is just one bug example
  // https://github.com/visionmedia/mocha/issues/333 has a good discussion
  function done() {
    if (!(draining--)) process.exit(code);
  }

  var draining = 0;
  var streams = [process.stdout, process.stderr];

  streams.forEach(function(stream){
    // submit empty write request and wait for completion
    draining += 1;
    stream.write('', done);
  });

  done();
}
```

when `exit` execute(without --no-exit), copy resource process will be stopped.
### Enhancement
- add callback when `reportGenerator` finished the task
- add `done` function for mochawesome. When all the process finished (runner test & report generate), do `exit` function from mocha.
- add `es6-promise` in package.json if use old version node.
