### PR TITLE
move mocha to peer dependecy for multi-mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
     "json-stringify-safe": "^5.0.0",
     "lodash": "^3.1.0",
     "mkdirp": "^0.5.1",
-    "mocha": "*",
     "moment": "^2.9.0",
     "ncp": "^1.0.1",
     "node-uuid": "^1.4.1",
     "opener": "^1.4.1"
+  },
+  "peerDependencies": {
+    "mocha": "*"
   },
   "devDependencies": {
     "bootstrap": "^3.3.2",


### PR DESCRIPTION
This is need for mocha-multi ( https://github.com/glenjamin/mocha-multi )  to work properly. 
See https://github.com/glenjamin/mocha-multi/issues/4#issuecomment-40956006