### PR TITLE
add correct reportFilename with full path to config

### DIFF
--- a/dist/config.js
+++ b/dist/config.js
@@ -9,7 +9,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var path = require('path');
 
 var baseConfig = {
-  reportDir: path.join('.', 'mochawesome-reports'),
+  reportDir: './mochawesome-reports',
   reportFilename: 'mochawesome',
   reportTitle: process.cwd().split(path.sep).pop(),
   reportPageTitle: 'Mochawesome Report Card',
@@ -37,9 +37,9 @@ function _getOption(optToGet, options, isBool) {
 
 module.exports = function (opts) {
   var options = {};
-  var reportFilename = _getOption('reportFilename', opts);
 
-  options.reportDir = _getOption('reportDir', opts);
+  options.reportFilename = _getOption('reportFilename', opts);
+  options.reportDir = path.resolve(_getOption('reportDir', opts));
   options.reportTitle = _getOption('reportTitle', opts);
   options.reportPageTitle = _getOption('reportPageTitle', opts);
   options.inlineAssets = _getOption('inlineAssets', opts, true);
@@ -49,8 +49,8 @@ module.exports = function (opts) {
   options.quiet = _getOption('quiet', opts, true);
 
   // Report Files
-  options.reportJsonFile = path.join(options.reportDir, reportFilename + '.json');
-  options.reportHtmlFile = path.join(options.reportDir, reportFilename + '.html');
+  options.reportJsonFile = path.join(options.reportDir, options.reportFilename + '.json');
+  options.reportHtmlFile = path.join(options.reportDir, options.reportFilename + '.html');
 
   return (0, _assign2.default)(baseConfig, options);
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const baseConfig = {
-  reportDir: path.join('.', 'mochawesome-reports'),
+  reportDir: './mochawesome-reports',
   reportFilename: 'mochawesome',
   reportTitle: process.cwd().split(path.sep).pop(),
   reportPageTitle: 'Mochawesome Report Card',
@@ -35,9 +35,9 @@ function _getOption(optToGet, options, isBool) {
 
 module.exports = function (opts) {
   const options = {};
-  const reportFilename = _getOption('reportFilename', opts);
 
-  options.reportDir = _getOption('reportDir', opts);
+  options.reportFilename = _getOption('reportFilename', opts);
+  options.reportDir = path.resolve(_getOption('reportDir', opts));
   options.reportTitle = _getOption('reportTitle', opts);
   options.reportPageTitle = _getOption('reportPageTitle', opts);
   options.inlineAssets = _getOption('inlineAssets', opts, true);
@@ -47,8 +47,8 @@ module.exports = function (opts) {
   options.quiet = _getOption('quiet', opts, true);
 
   // Report Files
-  options.reportJsonFile = path.join(options.reportDir, `${reportFilename}.json`);
-  options.reportHtmlFile = path.join(options.reportDir, `${reportFilename}.html`);
+  options.reportJsonFile = path.join(options.reportDir, `${options.reportFilename}.json`);
+  options.reportHtmlFile = path.join(options.reportDir, `${options.reportFilename}.html`);
 
   return Object.assign(baseConfig, options);
 };

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -2,6 +2,7 @@ const Mocha = require('mocha');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const Assert = require('assert').AssertionError;
+const path = require('path');
 
 const { Runner, Suite, Test } = Mocha;
 const makeTest = (title, doneFn) => new Test(title, doneFn);
@@ -11,9 +12,14 @@ const reportStub = sinon.stub();
 
 const mochawesome = proxyquire('../src/mochawesome', {
   'fs-extra': { outputFile: writeFileStub },
-  'mochawesome-report': {
+  'mochawesome-report-generator': {
     create: reportStub
   }
+});
+
+process.on('unhandledRejection', reason => {
+  console.error(reason);
+  process.exit(1);
 });
 
 describe('mochawesome reporter', () => {
@@ -121,7 +127,7 @@ describe('mochawesome reporter', () => {
     });
 
     it('should apply reporter options via environment variables', done => {
-      process.env.MOCHAWESOME_REPORTDIR = 'testReportDir';
+      process.env.MOCHAWESOME_REPORTDIR = 'testReportDir/subdir';
       process.env.MOCHAWESOME_INLINEASSETS = 'true';
       process.env.MOCHAWESOME_AUTOOPEN = false;
 
@@ -131,8 +137,7 @@ describe('mochawesome reporter', () => {
       subSuite.addTest(test);
 
       runner.run(failureCount => {
-        // console.log(mochaReporter.config);
-        mochaReporter.config.reportDir.should.equal('testReportDir');
+        mochaReporter.config.reportDir.should.equal(path.resolve(__dirname, '../testReportDir/subdir'));
         mochaReporter.config.inlineAssets.should.equal(true);
         mochaReporter.config.autoOpen.should.equal(false);
         done();
@@ -146,6 +151,7 @@ describe('mochawesome reporter', () => {
       mochaReporter = new mocha._reporter(runner, {
         reporterOptions: {
           reportDir: 'testReportDir',
+          reportFilename: 'testReportFilename',
           reportTitle: 'testReportTitle',
           inlineAssets: 'true',
           autoOpen: true,
@@ -158,7 +164,8 @@ describe('mochawesome reporter', () => {
 
 
       runner.run(failureCount => {
-        mochaReporter.config.reportDir.should.equal('testReportDir');
+        mochaReporter.config.reportDir.should.equal(path.resolve(__dirname, '../testReportDir'));
+        mochaReporter.config.reportFilename.should.equal('testReportFilename');
         mochaReporter.config.reportTitle.should.equal('testReportTitle');
         mochaReporter.config.inlineAssets.should.equal(true);
         mochaReporter.config.autoOpen.should.equal(true);

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -17,9 +17,12 @@ const mochawesome = proxyquire('../src/mochawesome', {
   }
 });
 
+// node throws a warning for unhandled promise rejections
+// these are expected in this test so we just handle here
+// to quiet the warning
 process.on('unhandledRejection', reason => {
   console.error(reason);
-  process.exit(1);
+  process.exit(0);
 });
 
 describe('mochawesome reporter', () => {


### PR DESCRIPTION
The `reportFilename` option was not being propagated to the `config` object which was not causing issues with generating/saving files but should be done for consistency.

This PR also updates the `reportDir` option to resolve to the full path which allows handling of relative paths as the option.