### PR TITLE
Show failed hooks in the report

### DIFF
--- a/dist/utils.js
+++ b/dist/utils.js
@@ -153,12 +153,25 @@ function cleanTest(test) {
     err: err,
     isRoot: test.parent && test.parent.root,
     uuid: test.uuid || /* istanbul ignore next: default */uuid.v4(),
-    parentUUID: test.parent && test.parent.uuid
+    parentUUID: test.parent && test.parent.uuid,
+    type: test.type
   };
 
   cleaned.skipped = !cleaned.pass && !cleaned.fail && !cleaned.pending;
 
   return cleaned;
+}
+
+/**
+ * Filters all failed hooks from suite
+ * And concates them to a single array
+ *
+ * @param {Object} suite
+ */
+function getFailedHooks(suite) {
+  var failedHooks = [].concat(suite._afterAll, suite._afterEach, suite._beforeAll, suite._beforeEach);
+  failedHooks = _.filter(failedHooks, { state: 'failed' });
+  return failedHooks;
 }
 
 /**
@@ -171,7 +184,7 @@ function cleanTest(test) {
  */
 function cleanSuite(suite, totalTestsRegistered) {
   suite.uuid = uuid.v4();
-  suite.tests = suite.tests.concat(suite._beforeAll, suite._beforeEach, suite._afterAll, suite._afterEach);
+  suite.tests = suite.tests.concat(getFailedHooks(suite));
   var cleanTests = _.map(suite.tests, cleanTest);
   var passingTests = _.filter(cleanTests, { state: 'passed' });
   var failingTests = _.filter(cleanTests, { state: 'failed' });

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -171,7 +171,7 @@ function cleanTest(test) {
  */
 function cleanSuite(suite, totalTestsRegistered) {
   suite.uuid = uuid.v4();
-
+  suite.tests = suite.tests.concat(suite._beforeAll, suite._beforeEach, suite._afterAll, suite._afterEach);
   var cleanTests = _.map(suite.tests, cleanTest);
   var passingTests = _.filter(cleanTests, { state: 'passed' });
   var failingTests = _.filter(cleanTests, { state: 'failed' });

--- a/src/utils.js
+++ b/src/utils.js
@@ -148,12 +148,25 @@ function cleanTest(test) {
     err,
     isRoot: test.parent && test.parent.root,
     uuid: test.uuid || /* istanbul ignore next: default */uuid.v4(),
-    parentUUID: test.parent && test.parent.uuid
+    parentUUID: test.parent && test.parent.uuid,
+    type: test.type
   };
 
   cleaned.skipped = (!cleaned.pass && !cleaned.fail && !cleaned.pending);
 
   return cleaned;
+}
+
+/**
+ * Filters all failed hooks from suite
+ * And concates them to a single array
+ *
+ * @param {Object} suite
+ */
+function getFailedHooks(suite) {
+  let failedHooks = [].concat(suite._afterAll, suite._afterEach, suite._beforeAll, suite._beforeEach);
+  failedHooks = _.filter(failedHooks, { state: 'failed' });
+  return failedHooks;
 }
 
 /**
@@ -166,7 +179,7 @@ function cleanTest(test) {
  */
 function cleanSuite(suite, totalTestsRegistered) {
   suite.uuid = uuid.v4();
-  suite.tests = suite.tests.concat(suite._beforeAll, suite._beforeEach, suite._afterAll, suite._afterEach);
+  suite.tests = suite.tests.concat(getFailedHooks(suite));
   const cleanTests = _.map(suite.tests, cleanTest);
   const passingTests = _.filter(cleanTests, { state: 'passed' });
   const failingTests = _.filter(cleanTests, { state: 'failed' });

--- a/src/utils.js
+++ b/src/utils.js
@@ -166,7 +166,7 @@ function cleanTest(test) {
  */
 function cleanSuite(suite, totalTestsRegistered) {
   suite.uuid = uuid.v4();
-
+  suite.tests = suite.tests.concat(suite._beforeAll, suite._beforeEach, suite._afterAll, suite._afterEach);
   const cleanTests = _.map(suite.tests, cleanTest);
   const passingTests = _.filter(cleanTests, { state: 'passed' });
   const failingTests = _.filter(cleanTests, { state: 'failed' });

--- a/src/utils.js
+++ b/src/utils.js
@@ -204,7 +204,7 @@ function cleanSuite(suite, totalTestsRegistered) {
   suite.hasSuites = suite.suites.length > 0;
   suite.totalTests = suite.tests.length;
   suite.totalPasses = passingTests.length;
-  suite.totalFailures = _.filter(failingTests, { type: 'test' }).length;
+  suite.totalFailures = failingTests.length;
   suite.totalPending = pendingTests.length;
   suite.totalSkipped = skippedTests.length;
   suite.hasPasses = passingTests.length > 0;

--- a/src/utils.js
+++ b/src/utils.js
@@ -204,7 +204,7 @@ function cleanSuite(suite, totalTestsRegistered) {
   suite.hasSuites = suite.suites.length > 0;
   suite.totalTests = suite.tests.length;
   suite.totalPasses = passingTests.length;
-  suite.totalFailures = failingTests.length;
+  suite.totalFailures = _.filter(failingTests, { type: 'test' }).length;
   suite.totalPending = pendingTests.length;
   suite.totalSkipped = skippedTests.length;
   suite.hasPasses = passingTests.length > 0;

--- a/test/sample-suite.js
+++ b/test/sample-suite.js
@@ -223,7 +223,8 @@ module.exports = {
         isRoot: undefined,
         uuid: 'e061e2eb-e4aa-49e4-b6f3-41bbb23752a9',
         parentUUID: undefined,
-        skipped: false
+        skipped: false,
+        type: 'test'
       } ],
       pending: [],
       root: false,
@@ -248,7 +249,8 @@ module.exports = {
         isRoot: undefined,
         uuid: 'e061e2eb-e4aa-49e4-b6f3-41bbb23752a9',
         parentUUID: undefined,
-        skipped: false
+        skipped: false,
+        type: 'test'
       } ],
       failures: [],
       skipped: [],

--- a/test/sample-tests.js
+++ b/test/sample-tests.js
@@ -89,7 +89,8 @@ module.exports = {
       isRoot: false,
       uuid: '0e877e24-a28b-4869-bcb4-7c3529d84ef6',
       parentUUID: 'a8a6bd0a-3e18-4aa3-ba36-f660e07ebed8',
-      skipped: false
+      skipped: false,
+      type: 'test'
     }
   },
   failing: {
@@ -204,7 +205,8 @@ module.exports = {
       isRoot: false,
       uuid: '2bcbe88c-acd6-4a53-ba3a-61a59188d5b0',
       parentUUID: '56508f44-b4e6-40f0-bae8-b15e0720f120',
-      skipped: false
+      skipped: false,
+      type: 'test'
     }
   },
   pending: {
@@ -288,7 +290,8 @@ module.exports = {
       isRoot: false,
       uuid: '6e8e6fe4-b2a1-4cdf-8f94-099f98b5b472',
       parentUUID: '88d24c3c-9262-4f6f-9419-a9fe259e3c95',
-      skipped: false
+      skipped: false,
+      type: 'test'
     }
   }
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -145,7 +145,8 @@ describe('Mochawesome Utils', () => {
       'isRoot',
       'uuid',
       'parentUUID',
-      'skipped'
+      'skipped',
+      'type'
     ];
 
     it('returns cleaned passing test', () => {


### PR DESCRIPTION
Resolve for #150 issue .
Added support for all hook failures :
- before all
- before each
- after all 
- after each

The hook will be shown like a test failure but will not affect the global statistic. 
Hook will be shown only when it failed
Sample report with hook failures : 
<img width="1170" alt="screen shot 2017-04-29 at 17 50 53" src="https://cloud.githubusercontent.com/assets/15690633/25556399/87612014-2d04-11e7-98e5-3e5b2a72e834.png">
Full html report is in here
https://gist.github.com/ramiloif/b0846b4aca19ce1a50a12260151c10b4
