### PR TITLE
support addContext inside beforeEach and afterEach hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### [2.2.0](https://github.com/adamgruber/mochawesome/releases/tag/2.2.0)
+- Enable using `addContext` in `beforeEach` and `afterEach` test hooks
+- Fix a bug where you could pass an object with empty title string to `addContext`
+- Allow a context value of `undefined` to be displayed in the report
+
 ### [2.1.0](https://github.com/adamgruber/mochawesome/releases/tag/2.1.0)
 - Added new options: `overwrite` and `timestamp`
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ var mocha = new Mocha({
 ## Adding Test Context
 One of the more request features has been the ability to display additional information about a test within the report. As of version 2.0.0 this is now possible with the `addContext` helper method. This method will add extra information to the test object that will then be displayed inside the report.
 
-### addContext(testObj, context)
+### `addContext(testObj, context)`
 
 param | type | description
 :---- | :--- | :----------
@@ -182,6 +182,26 @@ describe('test suite', function () {
       }
     });
   })
+});
+```
+
+As of version 2.2.0 it is possible to use `addContext` from within a `beforeEach` or `afterEach` test hook.
+```js
+describe('test suite', () => {
+  beforeEach(function () {
+    addContext(this, 'some context')
+  });
+
+  afterEach(function () {
+    addContext(this, {
+      title: 'afterEach context',
+      value: { a: 1 }
+    });
+  });
+
+  it('should display with beforeEach and afterEach context', () => {
+    // assert something
+  });
 });
 ```
 

--- a/src/addContext.js
+++ b/src/addContext.js
@@ -6,7 +6,11 @@ const stringify = require('json-stringify-safe');
 const errorPrefix = 'Error adding context:';
 const ERRORS = {
   INVALID_ARGS: `${errorPrefix} Invalid arguments.`,
-  INVALID_CONTEXT: `${errorPrefix} Expected a string or an object of shape { title: string, value: any } but saw:`
+  INVALID_TEST: `${errorPrefix} Invalid test object.`,
+  INVALID_CONTEXT: ctx => {
+    const expected = 'Expected a string or an object of shape { title: string, value: any } but saw:';
+    return `${errorPrefix} ${expected}\n${stringify(ctx, (key, val) => (val === undefined ? 'undefined' : val), 2)}`;
+  }
 };
 
 /**
@@ -27,10 +31,11 @@ function _isValidContext(ctx) {
   /*
    * Context is valid if any of the following are true:
    * 1. Type is string and it is not empty
-   * 2. Type is object and it has properties 'title' and 'value'
+   * 2. Type is object and it has properties `title` and `value` and `title` is not empty
    */
+  if (!ctx) return false;
   return ((typeof ctx === 'string') && !isEmpty(ctx))
-    || (Object.hasOwnProperty.call(ctx, 'title') && Object.hasOwnProperty.call(ctx, 'value'));
+    || (Object.hasOwnProperty.call(ctx, 'title') && !isEmpty(ctx.title) && Object.hasOwnProperty.call(ctx, 'value'));
 }
 
 /**
@@ -64,7 +69,7 @@ function _isValidContext(ctx) {
 
 const addContext = function (...args) {
   // Check args to see if we should bother continuing
-  if ((args.length !== 2) || !isObject(args[0]) || !args[0].test) {
+  if ((args.length !== 2) || !isObject(args[0])) {
     log(ERRORS.INVALID_ARGS, 'error');
     return;
   }
@@ -73,12 +78,28 @@ const addContext = function (...args) {
 
   // Ensure that context meets the requirements
   if (!_isValidContext(ctx)) {
-    log(`${ERRORS.INVALID_CONTEXT}\n${stringify(ctx, null, 2)}`, 'error');
+    log(ERRORS.INVALID_CONTEXT(ctx), 'error');
     return;
   }
 
-  // Context is valid we can proceed
-  const test = args[0].test;
+  /* Context is valid, now get the test object
+   * If `addContext` is called from inside a `beforeEach` or `afterEach`
+   * the test object will be `.currentTest`, otherwise just `.test`
+   */
+  const test = args[0].currentTest || args[0].test;
+
+  if (!test) {
+    log(ERRORS.INVALID_TEST, 'error');
+    return;
+  }
+
+  /* If context is an object, and value is `undefined`
+   * change it to 'undefined' so it can be displayed
+   * correctly in the report
+   */
+  if (ctx.title && ctx.value === undefined) {
+    ctx.value = 'undefined';
+  }
 
   // Test doesn't already have context -> set it
   if (!test.context) {

--- a/test-functional/test-context.js
+++ b/test-functional/test-context.js
@@ -85,4 +85,38 @@ describe('Master Test Suite', () => {
       (1+1).should.equal(2);
     });
   });
+
+  describe('beforeEach Context', () => {
+    beforeEach(function () {
+      addContext(this, 'this is the beforeEach context');
+    });
+
+    it('should have text context beforeEach context', function (done) {
+      (1+1).should.equal(2);
+      addContext(this, 'this is the test context');
+      done();
+    });
+    it('should have url context, no protocol and beforeEach context', function (done) {
+      (1+1).should.equal(2);
+      addContext(this, 'www.apple.com');
+      done();
+    });
+  });
+
+  describe('afterEach Context', () => {
+    beforeEach(function () {
+      addContext(this, 'this is the afterEach context');
+    });
+
+    it('should have text context afterEach context', function (done) {
+      (1+1).should.equal(2);
+      addContext(this, 'this is the test context');
+      done();
+    });
+    it('should have url context, no protocol and afterEach context', function (done) {
+      (1+1).should.equal(2);
+      addContext(this, 'www.apple.com');
+      done();
+    });
+  });
 });

--- a/test/addContext.test.js
+++ b/test/addContext.test.js
@@ -4,39 +4,70 @@ describe('addContext', () => {
   let testObj;
   let test;
 
-  beforeEach(() => {
-    testObj = { test: {} };
-    test = testObj.test;
-  });
-
-  it('should add context as string', () => {
-    addContext(testObj, 'test context');
-    test.should.eql({ context: 'test context' });
-  });
-
-  it('should add context as object', () => {
-    addContext(testObj, {
-      title: 'context title',
-      value: true
+  function contextTests() {
+    it('as a string', () => {
+      addContext(testObj, 'test context');
+      test.should.eql({ context: 'test context' });
     });
-    test.should.eql({
-      context: {
+
+    it('as an object', () => {
+      addContext(testObj, {
         title: 'context title',
         value: true
-      }
+      });
+      test.should.eql({
+        context: {
+          title: 'context title',
+          value: true
+        }
+      });
     });
+
+    it('as an object with undefined value', () => {
+      addContext(testObj, {
+        title: 'context title',
+        value: undefined
+      });
+      test.should.eql({
+        context: {
+          title: 'context title',
+          value: 'undefined'
+        }
+      });
+    });
+
+    it('as multiple items', () => {
+      addContext(testObj, 'test context 1');
+      addContext(testObj, 'test context 2');
+      addContext(testObj, { title: 'test context 3', value: true });
+      test.should.eql({
+        context: [ 'test context 1', 'test context 2', { title: 'test context 3', value: true } ]
+      });
+    });
+  }
+
+  describe('when run inside a test', () => {
+    beforeEach(() => {
+      testObj = { test: {} };
+      test = testObj.test;
+    });
+    contextTests();
   });
 
-  it('should add multiple context items', () => {
-    addContext(testObj, 'test context 1');
-    addContext(testObj, 'test context 2');
-    addContext(testObj, { title: 'test context 3', value: true });
-    test.should.eql({
-      context: [ 'test context 1', 'test context 2', { title: 'test context 3', value: true } ]
+  describe('when run inside a beforeEach', () => {
+    beforeEach(() => {
+      testObj = { currentTest: {} };
+      test = testObj.currentTest;
     });
+    contextTests();
   });
 
   describe('No context is added when', () => {
+    beforeEach(() => {
+      testObj = { test: {} };
+      test = testObj.test;
+    });
+
     it('wrong number of args', () => {
       addContext('');
       test.should.not.have.property('context');
@@ -59,6 +90,11 @@ describe('addContext', () => {
 
     it('wrong context object, no title', () => {
       addContext(testObj, { value: 'test' });
+      test.should.not.have.property('context');
+    });
+
+    it('wrong context object, empty title', () => {
+      addContext(testObj, { title: '', value: undefined });
       test.should.not.have.property('context');
     });
 


### PR DESCRIPTION
This PR enables the use of the `addContext` feature from within `beforeEach` and `afterEach` hooks.

#151 