### PR TITLE
separate before and after hooks

### DIFF
--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -73,9 +73,9 @@ function Mochawesome(runner, options) {
   const allPasses = [];
   let endCalled = false;
 
-  // Add a unique identifier to each test
+  // Add a unique identifier to each test/hook
   runner.on('test', test => (test.uuid = uuid.v4()));
-
+  runner.on('hook', hook => (hook.uuid = uuid.v4()));
   // Add test to array of all tests
   runner.on('test end', test => allTests.push(test));
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -158,17 +158,6 @@ function cleanTest(test) {
 }
 
 /**
- * Filters all failed hooks from suite
- * And concatenates them to a single array
- *
- * @param {Object} suite
- */
-function getFailedHooks(suite) {
-  const failedHooks = [].concat(suite._afterAll, suite._afterEach, suite._beforeAll, suite._beforeEach);
-  return _.filter(failedHooks, { state: 'failed' });
-}
-
-/**
  * Mutates the suite object to add properties needed to render
  * the template and remove unused properties.
  *
@@ -178,7 +167,8 @@ function getFailedHooks(suite) {
  */
 function cleanSuite(suite, totalTestsRegistered) {
   suite.uuid = uuid.v4();
-  const failedHooks = _.map(getFailedHooks(suite), cleanTest);
+  const beforeHooks = _.map([].concat(suite._beforeAll, suite._beforeEach), cleanTest);
+  const afterHooks = _.map([].concat(suite._afterAll, suite._afterEach), cleanTest);
   const cleanTests = _.map(suite.tests, cleanTest);
   const passingTests = _.filter(cleanTests, { state: 'passed' });
   const failingTests = _.filter(cleanTests, { state: 'failed' });
@@ -192,16 +182,18 @@ function cleanSuite(suite, totalTestsRegistered) {
 
   totalTestsRegistered.total += suite.tests.length;
 
+  suite.beforeHooks = beforeHooks;
+  suite.afterHooks = afterHooks;
   suite.tests = cleanTests;
-  suite.failedHooks = failedHooks;
   suite.fullFile = suite.file || '';
   suite.file = suite.file ? suite.file.replace(process.cwd(), '') : '';
   suite.passes = passingTests;
   suite.failures = failingTests;
   suite.pending = pendingTests;
   suite.skipped = skippedTests;
+  suite.hasBeforeHooks = suite.beforeHooks.length > 0;
+  suite.hasAfterHooks = suite.afterHooks.length > 0;
   suite.hasTests = suite.tests.length > 0;
-  suite.hasFailedHooks = suite.failedHooks.length > 0;
   suite.hasSuites = suite.suites.length > 0;
   suite.totalTests = suite.tests.length;
   suite.totalPasses = passingTests.length;
@@ -219,15 +211,17 @@ function cleanSuite(suite, totalTestsRegistered) {
     'title',
     'fullFile',
     'file',
+    'beforeHooks',
+    'afterHooks',
     'tests',
-    'failedHooks',
     'suites',
     'passes',
     'failures',
     'pending',
     'skipped',
+    'hasBeforeHooks',
+    'hasAfterHooks',
     'hasTests',
-    'hasFailedHooks',
     'hasSuites',
     'totalTests',
     'totalPasses',
@@ -278,6 +272,5 @@ module.exports = {
   cleanCode,
   cleanTest,
   cleanSuite,
-  getFailedHooks,
   traverseSuites
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -152,7 +152,7 @@ function cleanTest(test) {
     isHook: test.type === 'hook'
   };
 
-  cleaned.skipped = (!cleaned.pass && !cleaned.fail && !cleaned.pending);
+  cleaned.skipped = (!cleaned.pass && !cleaned.fail && !cleaned.pending && !cleaned.isHook);
 
   return cleaned;
 }

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -173,36 +173,13 @@ describe('Mochawesome Reporter', () => {
       });
     }
 
-    function skippedHookTest(hookType, isBefore) {
-      it(`${hookType} skipped hook`, done => {
-        const error = { expected: { a: 1 }, actual: { a: 2 } };
-        const test = makeTest('failing test', tDone => tDone(new Assert(error)));
-        subSuite[hookType](`${hookType} skipped hook`, () => {});
-        subSuite.addTest(test);
-        runner.run(failureCount => {
-          const testSuite = mochaReporter.runner.suite.suites[0];
-          const { hasBeforeHooks, hasAfterHooks, beforeHooks, afterHooks } = testSuite;
-          hasBeforeHooks.should.equal(isBefore);
-          hasAfterHooks.should.equal(!isBefore);
-          afterHooks.length.should.equal(isBefore ? 0 : 1);
-          beforeHooks.length.should.equal(isBefore ? 1 : 0);
-          isBefore
-            ? beforeHooks[0].skipped.should.equal(true)
-            : afterHooks[0].skipped.should.equal(true);
-          done();
-        });
-      });
-    }
-
     [ 'beforeAll', 'beforeEach' ].forEach(type => {
       passingHookTest(type, true);
       failingHookTest(type, true);
-      skippedHookTest(type, true);
     });
 
     [ 'afterAll', 'afterEach' ].forEach(type => {
       passingHookTest(type, false);
-      skippedHookTest(type, false);
       failingHookTest(type, false);
     });
   });

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -137,68 +137,73 @@ describe('Mochawesome Reporter', () => {
   });
 
   describe('Hook Handling', () => {
-    it('Before each failing hook', done => {
-      const test = makeTest('passing test', () => {});
-      subSuite.beforeEach('Before Each failure', () => {
-        throw new Error('Dummy hook error');
+    function passingHookTest(hookType, isBefore) {
+      it(`${hookType} passing hook`, done => {
+        const test = makeTest('passing test', () => {});
+        subSuite[hookType](`${hookType} passing hook`, () => {});
+        subSuite.addTest(test);
+        runner.run(failureCount => {
+          const testSuite = mochaReporter.runner.suite.suites[0];
+          const { hasBeforeHooks, hasAfterHooks, beforeHooks, afterHooks } = testSuite;
+          hasBeforeHooks.should.equal(isBefore);
+          hasAfterHooks.should.equal(!isBefore);
+          afterHooks.length.should.equal(isBefore ? 0 : 1);
+          beforeHooks.length.should.equal(isBefore ? 1 : 0);
+          done();
+        });
       });
-      subSuite.addTest(test);
-      runner.run(failureCount => {
-        mochaReporter.runner.suite.suites[0].hasFailedHooks.should.equal(true);
-        mochaReporter.runner.suite.suites[0].failedHooks.length.should.equal(1);
-        done();
+    }
+
+    function failingHookTest(hookType, isBefore) {
+      it(`${hookType} failing hook`, done => {
+        const test = makeTest('passing test', () => {});
+        subSuite[hookType](`${hookType} failing hook`, () => {
+          throw new Error('Dummy hook error');
+        });
+        subSuite.addTest(test);
+        runner.run(failureCount => {
+          const testSuite = mochaReporter.runner.suite.suites[0];
+          const { hasBeforeHooks, hasAfterHooks, beforeHooks, afterHooks } = testSuite;
+          hasBeforeHooks.should.equal(isBefore);
+          hasAfterHooks.should.equal(!isBefore);
+          afterHooks.length.should.equal(isBefore ? 0 : 1);
+          beforeHooks.length.should.equal(isBefore ? 1 : 0);
+          done();
+        });
       });
+    }
+
+    function skippedHookTest(hookType, isBefore) {
+      it(`${hookType} skipped hook`, done => {
+        const error = { expected: { a: 1 }, actual: { a: 2 } };
+        const test = makeTest('failing test', tDone => tDone(new Assert(error)));
+        subSuite[hookType](`${hookType} skipped hook`, () => {});
+        subSuite.addTest(test);
+        runner.run(failureCount => {
+          const testSuite = mochaReporter.runner.suite.suites[0];
+          const { hasBeforeHooks, hasAfterHooks, beforeHooks, afterHooks } = testSuite;
+          hasBeforeHooks.should.equal(isBefore);
+          hasAfterHooks.should.equal(!isBefore);
+          afterHooks.length.should.equal(isBefore ? 0 : 1);
+          beforeHooks.length.should.equal(isBefore ? 1 : 0);
+          isBefore
+            ? beforeHooks[0].skipped.should.equal(true)
+            : afterHooks[0].skipped.should.equal(true);
+          done();
+        });
+      });
+    }
+
+    [ 'beforeAll', 'beforeEach' ].forEach(type => {
+      passingHookTest(type, true);
+      failingHookTest(type, true);
+      skippedHookTest(type, true);
     });
 
-    it('Before all failing hook', done => {
-      const test = makeTest('passing test', () => {});
-      subSuite.beforeAll('Before All failure', () => {
-        throw new Error('Dummy hook error');
-      });
-      subSuite.addTest(test);
-      runner.run(failureCount => {
-        mochaReporter.runner.suite.suites[0].hasFailedHooks.should.equal(true);
-        mochaReporter.runner.suite.suites[0].failedHooks.length.should.equal(1);
-        done();
-      });
-    });
-
-    it('After each failing hook', done => {
-      const test = makeTest('passing test', () => {});
-      subSuite.afterEach('After Each failure', () => {
-        throw new Error('Dummy hook error');
-      });
-      subSuite.addTest(test);
-      runner.run(failureCount => {
-        mochaReporter.runner.suite.suites[0].hasFailedHooks.should.equal(true);
-        mochaReporter.runner.suite.suites[0].failedHooks.length.should.equal(1);
-        done();
-      });
-    });
-
-    it('After all failing hook', done => {
-      const test = makeTest('passing test', () => {});
-      subSuite.afterAll('After all failure', () => {
-        throw new Error('Dummy hook error');
-      });
-      subSuite.addTest(test);
-      runner.run(failureCount => {
-        mochaReporter.runner.suite.suites[0].hasFailedHooks.should.equal(true);
-        mochaReporter.runner.suite.suites[0].failedHooks.length.should.equal(1);
-        done();
-      });
-    });
-
-    it('Should not have skipped hook in the report', done => {
-      const error = { expected: { a: 1 }, actual: { a: 2 } };
-      const test = makeTest('failing test', tDone => tDone(new Assert(error)));
-      subSuite.afterAll('Skipped hook', () => {});
-      subSuite.addTest(test);
-      runner.run(failureCount => {
-        mochaReporter.runner.suite.suites[0].hasFailedHooks.should.equal(false);
-        mochaReporter.runner.suite.suites[0].failedHooks.length.should.equal(0);
-        done();
-      });
+    [ 'afterAll', 'afterEach' ].forEach(type => {
+      passingHookTest(type, false);
+      skippedHookTest(type, false);
+      failingHookTest(type, false);
     });
   });
 

--- a/test/sample-suite.js
+++ b/test/sample-suite.js
@@ -1,3 +1,5 @@
+const tests = require('./sample-tests');
+
 /* eslint-disable */
 module.exports = {
   one: {
@@ -109,8 +111,9 @@ module.exports = {
         delayed: false,
         parent: '[Circular ~]'
       } ],
+      beforeHooks: [],
+      afterHooks: [],
       tests: [],
-      failedHooks: [],
       pending: [],
       root: true,
       _timeout: 2000,
@@ -120,8 +123,9 @@ module.exports = {
       passes: [],
       failures: [],
       skipped: [],
+      hasBeforeHooks: false,
+      hasAfterHooks: false,
       hasTests: false,
-      hasFailedHooks: false,
       hasSuites: true,
       totalTests: 0,
       totalPasses: 0,
@@ -165,36 +169,8 @@ module.exports = {
         speed: 'fast'
       } ],
       pending: false,
-      _beforeEach: [],
-      _beforeAll: [
-        {
-        title:  "\"before all\" hook",
-        body: "() => {\n            throw new Error();\n        }",
-        async: 0,
-        sync: true,
-        _timeout: 2000,
-        _slow: 75,
-        _enableTimeouts: true,
-        timedOut: false,
-        _trace: {},
-        _retries: -1,
-        _currentRetry: 0,
-        pending: false,
-        type: "hook",
-        parent: "[Circular ~]",
-        ctx: {
-          _runnable: "[Circular ~._beforeAll.0]",
-          test: "[Circular ~._beforeAll.0]"
-        },
-        uuid: 'e061e1eb-e9aa-49e4-b6f3-41bbb27752a8',
-        _events: {},
-        _eventsCount: 1,
-        duration: 0,
-        _error: null,
-        state: "failed",
-        err: {}
-    }
-      ],
+      _beforeEach: [tests.hook.raw],
+      _beforeAll: [],
       _afterEach: [],
       _afterAll: [],
       root: false,
@@ -256,27 +232,8 @@ module.exports = {
         skipped: false,
         isHook: false
       } ],
-      failedHooks: [
-        {
-        title: "\"before all\" hook",
-        fullTitle: "\"before all\" hook",
-        timedOut: false,
-        duration: 0,
-        state: "failed",
-        pass: false,
-        fail: true,
-        pending: false,
-        context: undefined,
-        code: "throw new Error();",
-        err: {},
-        isRoot: undefined,
-        uuid: "e061e1eb-e9aa-49e4-b6f3-41bbb27752a8",
-        parentUUID: undefined,
-        skipped: false,
-        speed: undefined,
-        isHook: true
-      }
-      ],
+      beforeHooks: [tests.hook.cleaned],
+      afterHooks: [],
       pending: [],
       root: false,
       rootEmpty: false,
@@ -305,8 +262,9 @@ module.exports = {
       } ],
       failures: [],
       skipped: [],
+      hasBeforeHooks: true,
+      hasAfterHooks: false,
       hasTests: true,
-      hasFailedHooks: true,
       hasSuites: false,
       totalTests: 1,
       totalPasses: 1,

--- a/test/sample-tests.js
+++ b/test/sample-tests.js
@@ -293,5 +293,235 @@ module.exports = {
       skipped: false,
       isHook: false
     }
+  },
+  hook: {
+    raw: {
+      title: '\"before each\" hook: failing beforeEach hook for \"passing test\"',
+      body: 'function () {\n      console.log(a); // eslint-disable-line\n    }',
+      async: 0,
+      sync: true,
+      _timeout: 2000,
+      _slow: 75,
+      _enableTimeouts: true,
+      timedOut: false,
+      _trace: {},
+      _retries: -1,
+      _currentRetry: 0,
+      pending: false,
+      type: 'hook',
+      parent: {
+        title: 'Test Suite - Failed Before Each',
+        ctx: {
+          currentTest: {
+            title: 'passing test',
+            body: 'function (done) {\n      (1 1).should.equal(2);\n      done();\n    }',
+            async: 1,
+            sync: false,
+            _timeout: 2000,
+            _slow: 75,
+            _enableTimeouts: true,
+            timedOut: false,
+            _trace: {},
+            _retries: -1,
+            _currentRetry: 0,
+            pending: false,
+            type: 'test',
+            file: '/Users/adamg/Sites/mafork/test-functional/test-hooks.js',
+            parent: '[Circular ~.parent]',
+            ctx: '[Circular ~.parent.ctx]',
+            uuid: 'fde7ab64-61b9-4c6d-b893-6f013a6317db'
+          },
+          _runnable: '[Circular ~]',
+          test: '[Circular ~]'
+        },
+        suites: [],
+        tests: [
+          {
+            title: 'passing test',
+            body: 'function (done) {\n      (1 1).should.equal(2);\n      done();\n    }',
+            async: 1,
+            sync: false,
+            _timeout: 2000,
+            _slow: 75,
+            _enableTimeouts: true,
+            timedOut: false,
+            _trace: {},
+            _retries: -1,
+            _currentRetry: 0,
+            pending: false,
+            type: 'test',
+            file: '/Users/adamg/Sites/mafork/test-functional/test-hooks.js',
+            parent: '[Circular ~.parent]',
+            ctx: {
+              currentTest: '[Circular ~.parent.tests.0]',
+              _runnable: '[Circular ~]',
+              test: '[Circular ~]'
+            },
+            uuid: 'fde7ab64-61b9-4c6d-b893-6f013a6317db'
+          }
+        ],
+        pending: false,
+        _beforeEach: [
+          '[Circular ~]'
+        ],
+        _beforeAll: [],
+        _afterEach: [],
+        _afterAll: [],
+        root: false,
+        _timeout: 2000,
+        _enableTimeouts: true,
+        _slow: 75,
+        _retries: -1,
+        _onlyTests: [],
+        _onlySuites: [],
+        delayed: false,
+        parent: {
+          title: 'Hooks',
+          suites: [
+            '[Circular ~.parent]'
+          ],
+          tests: [],
+          pending: [],
+          root: false,
+          _timeout: 2000,
+          file: '/test-functional/test-hooks.js',
+          uuid: '93a639a5-429e-44a0-854c-6758408fca62',
+          beforeHooks: [],
+          afterHooks: [],
+          fullFile: '/Users/adamg/Sites/mafork/test-functional/test-hooks.js',
+          passes: [],
+          failures: [],
+          skipped: [],
+          hasBeforeHooks: false,
+          hasAfterHooks: false,
+          hasTests: false,
+          hasSuites: true,
+          totalTests: 0,
+          totalPasses: 0,
+          totalFailures: 0,
+          totalPending: 0,
+          totalSkipped: 0,
+          hasPasses: false,
+          hasFailures: false,
+          hasPending: false,
+          hasSkipped: false,
+          duration: 0,
+          rootEmpty: false
+        },
+        file: '/Users/adamg/Sites/mafork/test-functional/test-hooks.js',
+        uuid: '3303effe-2b74-4156-a141-6cf51324e8f5'
+      },
+      ctx: {
+        currentTest: {
+          title: 'passing test',
+          body: 'function (done) {\n      (1 1).should.equal(2);\n      done();\n    }',
+          async: 1,
+          sync: false,
+          _timeout: 2000,
+          _slow: 75,
+          _enableTimeouts: true,
+          timedOut: false,
+          _trace: {},
+          _retries: -1,
+          _currentRetry: 0,
+          pending: false,
+          type: 'test',
+          file: '/Users/adamg/Sites/mafork/test-functional/test-hooks.js',
+          parent: {
+            title: 'Test Suite - Failed Before Each',
+            ctx: '[Circular ~.ctx]',
+            suites: [],
+            tests: [
+              '[Circular ~.ctx.currentTest]'
+            ],
+            pending: false,
+            _beforeEach: [
+              '[Circular ~]'
+            ],
+            _beforeAll: [],
+            _afterEach: [],
+            _afterAll: [],
+            root: false,
+            _timeout: 2000,
+            _enableTimeouts: true,
+            _slow: 75,
+            _retries: -1,
+            _onlyTests: [],
+            _onlySuites: [],
+            delayed: false,
+            parent: {
+              title: 'Hooks',
+              suites: [
+                '[Circular ~.ctx.currentTest.parent]'
+              ],
+              tests: [],
+              pending: [],
+              root: false,
+              _timeout: 2000,
+              file: '/test-functional/test-hooks.js',
+              uuid: '93a639a5-429e-44a0-854c-6758408fca62',
+              beforeHooks: [],
+              afterHooks: [],
+              fullFile: '/Users/adamg/Sites/mafork/test-functional/test-hooks.js',
+              passes: [],
+              failures: [],
+              skipped: [],
+              hasBeforeHooks: false,
+              hasAfterHooks: false,
+              hasTests: false,
+              hasSuites: true,
+              totalTests: 0,
+              totalPasses: 0,
+              totalFailures: 0,
+              totalPending: 0,
+              totalSkipped: 0,
+              hasPasses: false,
+              hasFailures: false,
+              hasPending: false,
+              hasSkipped: false,
+              duration: 0,
+              rootEmpty: false
+            },
+            file: '/Users/adamg/Sites/mafork/test-functional/test-hooks.js',
+            uuid: '3303effe-2b74-4156-a141-6cf51324e8f5'
+          },
+          ctx: '[Circular ~.ctx]',
+          uuid: 'fde7ab64-61b9-4c6d-b893-6f013a6317db'
+        },
+        _runnable: '[Circular ~]',
+        test: '[Circular ~]'
+      },
+      uuid: '51933158-66a0-4b6c-bc04-65d7ce24804b',
+      _events: {},
+      _eventsCount: 1,
+      duration: 0,
+      _error: null,
+      originalTitle: '\"before each\" hook: failing beforeEach hook',
+      state: 'failed',
+      err: {
+        estack: 'ReferenceError: a is not defined\n    at Context.<anonymous> (test-functional/test-hooks.js:4:19)'
+      }
+    },
+    cleaned: {
+      title: '\"before each\" hook: failing beforeEach hook for \"passing test\"',
+      fullTitle: '\"before each\" hook: failing beforeEach hook for \"passing test\"',
+      timedOut: false,
+      duration: 0,
+      state: 'failed',
+      speed: undefined,
+      pass: false,
+      fail: true,
+      pending: false,
+      context: undefined,
+      code: 'console.log(a); // eslint-disable-line',
+      err: {
+        estack: 'ReferenceError: a is not defined\n    at Context.<anonymous> (test-functional/test-hooks.js:4:19)'
+      },
+      isRoot: false,
+      uuid: '51933158-66a0-4b6c-bc04-65d7ce24804b',
+      parentUUID: '3303effe-2b74-4156-a141-6cf51324e8f5',
+      isHook: true,
+      skipped: false
+    }
   }
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -14,8 +14,7 @@ const {
   removeAllPropsFromObjExcept,
   cleanCode,
   cleanTest,
-  cleanSuite,
-  getFailedHooks
+  cleanSuite
 } = utils;
 
 describe('Mochawesome Utils', () => {
@@ -146,7 +145,8 @@ describe('Mochawesome Utils', () => {
       'isRoot',
       'uuid',
       'parentUUID',
-      'skipped'
+      'skipped',
+      'isHook'
     ];
 
     it('returns cleaned passing test', () => {
@@ -169,6 +169,13 @@ describe('Mochawesome Utils', () => {
       cleaned.should.have.properties(expectedProps);
       cleaned.should.deepEqual(sampleTests.pending.cleaned);
     });
+
+    it('returns cleaned hook', () => {
+      const cleaned = cleanTest(sampleTests.hook.raw);
+      delete cleaned.err.stack;
+      cleaned.should.have.properties(expectedProps);
+      cleaned.should.deepEqual(sampleTests.hook.cleaned);
+    });
   });
 
   describe('cleanSuite', () => {
@@ -177,15 +184,17 @@ describe('Mochawesome Utils', () => {
       'title',
       'fullFile',
       'file',
+      'beforeHooks',
+      'afterHooks',
       'tests',
-      'failedHooks',
       'suites',
       'passes',
       'failures',
       'pending',
       'skipped',
+      'hasBeforeHooks',
+      'hasAfterHooks',
       'hasTests',
-      'hasFailedHooks',
       'hasSuites',
       'totalTests',
       'totalPasses',
@@ -215,15 +224,6 @@ describe('Mochawesome Utils', () => {
       cleanSuite(s, totalTestsRegistered);
       s.should.have.properties(expectedProps);
       s.should.deepEqual(sampleSuite.two.cleaned);
-    });
-  });
-
-  describe('getFailedHooks', () => {
-    it('passing suit with one failed hook', () => {
-      const s = cloneDeep(sampleSuite.two.raw);
-      const hooks = getFailedHooks(s);
-      hooks.length.should.equal(1);
-      hooks[0].type.should.equal('hook');
     });
   });
 });


### PR DESCRIPTION
This PR cleans up #157
- Splits before/after hooks into their own arrays
- Includes all hooks instead of just failing ones