### PR TITLE
Fix options handling

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -52,7 +52,6 @@ module.exports = function (opts) {
     'enableCharts',
     'enableCode',
     'inlineAssets',
-    'inlineDiffs',
     'overwrite',
     'quiet',
     'reportDir',

--- a/src/config.js
+++ b/src/config.js
@@ -40,12 +40,6 @@ module.exports = function (opts) {
   const options = {};
   const reporterOpts = (opts && opts.reporterOptions) || {};
 
-  // Added for compatibility. enableTestCode option is deprecated as of 2.0.3
-  if (Object.hasOwnProperty.call(reporterOpts, 'enableTestCode')) {
-    reporterOpts.enableCode = reporterOpts.enableTestCode;
-    delete reporterOpts.enableTestCode;
-  }
-
   [
     'autoOpen',
     'dev',

--- a/src/config.js
+++ b/src/config.js
@@ -1,28 +1,20 @@
-const marge = require('mochawesome-report-generator');
-
-// Grab shared base config from mochawesome-report-generator
-const baseConfig = Object.assign(marge.getBaseConfig(), {
-  reportFilename: 'mochawesome',
-  saveJson: true
-});
-
-const boolOpts = [
-  'autoOpen',
-  'dev',
-  'enableCharts',
-  'enableCode',
-  'inlineAssets',
-  'overwrite',
-  'quiet',
-  'useInlineDiffs'
-];
-
-function _getOption(optToGet, options, isBool) {
+/**
+ * Retrieve the value of a user supplied option.
+ * Falls back to `defaultValue`
+ * Order of precedence
+ *  1. User-supplied option
+ *  2. Environment variable
+ *  3. Default value
+ *
+ * @param {string} optToGet  Option name
+ * @param {object} options  User supplied options object
+ * @param {boolean} isBool  Treat option as Boolean
+ * @param {string|boolean} defaultValue  Fallback value
+ *
+ * @return {string|boolean}  Option value
+ */
+function _getOption(optToGet, options, isBool, defaultValue) {
   const envVar = `MOCHAWESOME_${optToGet.toUpperCase()}`;
-  // Order of precedence
-  // 1. Config option
-  // 2. Environment variable
-  // 3. Base config
   if (options && typeof options[optToGet] !== 'undefined') {
     return (isBool && typeof options[optToGet] === 'string')
       ? options[optToGet] === 'true'
@@ -33,37 +25,15 @@ function _getOption(optToGet, options, isBool) {
       ? process.env[envVar] === 'true'
       : process.env[envVar];
   }
-  return baseConfig[optToGet];
+  return defaultValue;
 }
 
 module.exports = function (opts) {
-  const options = {};
   const reporterOpts = (opts && opts.reporterOptions) || {};
-
-  [
-    'autoOpen',
-    'dev',
-    'enableCharts',
-    'enableCode',
-    'inlineAssets',
-    'overwrite',
-    'quiet',
-    'reportDir',
-    'reportFilename',
-    'reportPageTitle',
-    'reportTitle',
-    'showHooks',
-    'timestamp'
-  ].forEach(optName => {
-    options[optName] = _getOption(optName, reporterOpts, boolOpts.indexOf(optName) >= 0);
-  });
-
-  // Transfer options from mocha
-  [
-    'useInlineDiffs'
-  ].forEach(optName => {
-    options[optName] = _getOption(optName, opts, boolOpts.indexOf(optName) >= 0);
-  });
-
-  return Object.assign(baseConfig, options);
+  return {
+    quiet: _getOption('quiet', reporterOpts, true, false),
+    reportFilename: _getOption('reportFilename', reporterOpts, false, 'mochawesome'),
+    saveJson: _getOption('json', reporterOpts, true, true),
+    useInlineDiffs: !!opts.useInlineDiffs
+  };
 };


### PR DESCRIPTION
This PR along with https://github.com/adamgruber/mochawesome-report-generator/pull/59 aim to simplify the options handling and consolidate it into one place, the report generator.

The reporter is still responsible for a few options but the majority are now just passed through to the report generator to handle.

- Handle only options that pertain to the reporter
- Pass all other options through to the report generator as is
- No longer rely on marge for base config