### PR TITLE
Add html option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Option Name | Type | Default | Description
 :---------- | :--- | :------ | :----------
 `quiet` | boolean | false | Silence console messages
 `reportFilename` | string | mochawesome | Filename of saved report <br> *Applies to the generated html and json files.*
+`html` | boolean | true | Save the HTML output for the test run
 `json` | boolean | true | Save the JSON output for the test run
 
 

--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,7 @@ module.exports = function (opts) {
   return {
     quiet: _getOption('quiet', reporterOpts, true, false),
     reportFilename: _getOption('reportFilename', reporterOpts, false, 'mochawesome'),
+    saveHtml: _getOption('html', reporterOpts, true, true),
     saveJson: _getOption('json', reporterOpts, true, true),
     useInlineDiffs: !!opts.useInlineDiffs
   };

--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -58,6 +58,7 @@ function Mochawesome(runner, options) {
     (options.reporterOptions || {}),
     {
       reportFilename: this.config.reportFilename,
+      saveHtml: this.config.saveHtml,
       saveJson: this.config.saveJson
     }
   );

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -15,6 +15,7 @@ utils.log = logStub;
 const baseConfig = {
   quiet: false,
   reportFilename: 'mochawesome',
+  saveHtml: true,
   saveJson: true,
   useInlineDiffs: false
 };
@@ -276,6 +277,7 @@ describe('Mochawesome Reporter', () => {
           inlineAssets: true,
           quiet: true,
           reportFilename: 'mochawesome',
+          saveHtml: true,
           saveJson: true
         });
       });


### PR DESCRIPTION
This adds the `html` option which defaults to `true`. If set to `false` the report generator will not generate an HTML file or any assets.

*This PR only adds the option. Updates to the report generator are required in order to implement this option.*

https://github.com/adamgruber/mochawesome/issues/173