### PR TITLE
Add a parameter to set the default filters when generating the report.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ export MOCHAWESOME_REPORTFILENAME=customReportFilename
 #### Mocha reporter-options
 You can pass comma-separated options to the reporter via mocha's `--reporter-options` flag. Options passed this way will take precedence over environment variables.
 ```bash
-$ mocha test.js --reporter mochawesome --reporter-options reportDir=customReportDir,reportFilename=customReportFilename
+$ mocha test.js --reporter mochawesome --reporter-options reportDir=customReportDir,reportFilename=customReportFilename,filter=passed+failed
 ```
 Alternately, `reporter-options` can be passed in programatically:
 
@@ -102,6 +102,7 @@ Option Name | Type | Default | Description
 `reportFilename` | string | mochawesome | Filename of saved report <br> *Applies to the generated html and json files.*
 `html` | boolean | true | Save the HTML output for the test run
 `json` | boolean | true | Save the JSON output for the test run
+`filter` | string | all | Set the filters to be applied after generating the report.
 
 
 ### Adding Test Context

--- a/src/config.js
+++ b/src/config.js
@@ -35,6 +35,7 @@ module.exports = function (opts) {
     reportFilename: _getOption('reportFilename', reporterOpts, false, 'mochawesome'),
     saveHtml: _getOption('html', reporterOpts, true, true),
     saveJson: _getOption('json', reporterOpts, true, true),
-    useInlineDiffs: !!opts.useInlineDiffs
+    useInlineDiffs: !!opts.useInlineDiffs,
+    filter: _getOption('filter', reporterOpts, false, 'all')
   };
 };

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -17,7 +17,8 @@ const baseConfig = {
   reportFilename: 'mochawesome',
   saveHtml: true,
   saveJson: true,
-  useInlineDiffs: false
+  useInlineDiffs: false,
+  filter: 'all'
 };
 
 const mochawesome = proxyquire('../src/mochawesome', {
@@ -245,7 +246,8 @@ describe('Mochawesome Reporter', () => {
         reporterOptions: {
           reportDir: 'testDir',
           inlineAssets: true,
-          quiet: true
+          quiet: true,
+          filter: 'all'
         }
       });
     });
@@ -278,7 +280,8 @@ describe('Mochawesome Reporter', () => {
           quiet: true,
           reportFilename: 'mochawesome',
           saveHtml: true,
-          saveJson: true
+          saveJson: true,
+          filter: 'all'
         });
       });
     });


### PR DESCRIPTION
- Adds a new parameter `filter` which is going to be included in the generator in this PR: https://github.com/adamgruber/mochawesome-report-generator/pull/61
- The new parameter was tested using the functional and programatic tests.