### PR TITLE
Fix RegExp for cleaning code

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:prog": "node ./test-programmatic",
     "test:mem": "mocha test-functional/mem-test.js --opts test-functional/mocha.opts",
     "test:ctx": "mocha test-functional/test-context.js --opts test-functional/mocha.opts",
+    "tdd": "npm run lint && cross-env NODE_ENV=test nyc mocha --watch",
     "dev": "babel --watch src -d dist",
     "build": "babel src -d dist",
     "prepack": "npm run test && npm run build"

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,8 +52,8 @@ function getPercentClass(pct) {
 function cleanCode(str) {
   str = str
     .replace(/\r\n?|[\n\u2028\u2029]/g, '\n').replace(/^\uFEFF/, '')
-    .replace(/^(async\s*)?(\(.*\)|function\*?)\s*(=>|\(.*\))?\s*{?/, '')
-    .replace(/\s*\}$/, '');
+    .replace(/^(async\s*)?(\(\w*\)|function\*?)\s*(=>|\(.*\))?\s*{?/, '')
+    .replace(/\s*}$/, '');
 
   const spaces = str.match(/^\n?( *)/)[1].length;
   const tabs = str.match(/^\n?(\t*)/)[1].length;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -103,6 +103,11 @@ describe('Mochawesome Utils', () => {
       cleanCode(fnStr).should.equal(expected);
     });
 
+    it('should clean arrow function syntax, single line no braces', () => {
+      fnStr = '() => someFunction(arg)';
+      cleanCode(fnStr).should.equal('someFunction(arg)');
+    });
+
     it('should clean arrow function syntax, multi line', () => {
       fnStr = `()=> {
         return true;


### PR DESCRIPTION
Update RegExp in `cleanCode` method to handle arrow functions without braces.

Fixes https://github.com/adamgruber/mochawesome/issues/220