### PR TITLE
Invert logic for retrieving test code string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # mochawesome changelog
 
-## Unreleased
+## [Unreleased]
+### Changed
+- Invert logic for getting test code by checking for `test.body` before `test.fn` inside `cleanTest` method [#252](https://github.com/adamgruber/mochawesome/issues/252)
 
 ## [3.0.3] / 2018-07-25
 ### Changed
@@ -161,6 +163,7 @@ This release is in tandem with and requires mochawesome-report-generator >= 3.0.
 - Custom font-icon set
 - All fonts are now local to the report
 
+[Unreleased]: https://github.com/adamgruber/mochawesome/compare/3.0.3...HEAD
 [3.0.3]: https://github.com/adamgruber/mochawesome/compare/3.0.2...3.0.3
 [3.0.2]: https://github.com/adamgruber/mochawesome/compare/3.0.1...3.0.2
 [3.0.1]: https://github.com/adamgruber/mochawesome/compare/3.0.0...3.0.1

--- a/src/utils.js
+++ b/src/utils.js
@@ -161,8 +161,13 @@ function normalizeErr(err, config) {
  * @return {Object} cleaned test
  */
 function cleanTest(test, config) {
-  /* istanbul ignore next: test.fn exists prior to mocha 2.4.0 */
-  const code = test.fn ? test.fn.toString() : test.body;
+  let code = test.body;
+
+  /* istanbul ignore next */
+  if (code === undefined) {
+    /* istanbul ignore next: test.fn exists prior to mocha 2.4.0 */
+    code = test.fn ? test.fn.toString() : '';
+  }
 
   const cleaned = {
     title: stripAnsi(test.title),


### PR DESCRIPTION
Since mocha@2.4.1, `test` objects have a `body` property that stores a string of the test code. This PR updates mochawesome to check for this property first, before falling back to `test.fn` thus avoiding cases where `test.fn.toString()` can produce unexpected results, as in #252.