### PR TITLE
Updated passing and pending percentage rounding logic

### DIFF
--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -119,9 +119,10 @@ function Mochawesome(runner, options) {
         obj.stats.testsRegistered = totalTestsRegistered.total;
 
         const { passes, failures, pending, tests, testsRegistered } = obj.stats;
-        const passPercentage = Math.round((passes / (testsRegistered - pending)) * 1000) / 10;
-        const pendingPercentage = Math.round((pending / testsRegistered) * 1000) /10;
-
+        const passPercentageUnrounded = (passes/(passes + failures)) * 100;
+        const passPercentage = Math.round(passPercentageUnrounded * 100) / 100; // Rounds to two decimal places        
+        const pendingPercentageUnrounded = (pending/testsRegistered) * 100;
+        const pendingPercentage = Math.round(pendingPercentageUnrounded * 100) / 100; // Rounds to two decimal places
         obj.stats.passPercent = passPercentage;
         obj.stats.pendingPercent = pendingPercentage;
         obj.stats.other = (passes + failures + pending) - tests;


### PR DESCRIPTION
The previous passing and pending percentage logic was rounding up to 100% in larger test suites. The updated logic rounds just the decimal (not integer) to two decimal places. This provides a more accurate read out. So, for example 1 failure / 2000 tests is 99.95% instead of 100%.