### PR TITLE
Suite duration fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,30 @@
 # mochawesome changelog
 
 ## [Unreleased]
+### Fixed
+- Issue where a suite with skipped tests reports duration as `0`. [#276](https://github.com/adamgruber/mochawesome/issues/276)
 
-## [3.1.1] / 2018-10-22
+## [3.1.1] - 2018-10-22
 ### Changed
 - Switch from RegExp to state machine for stripping function start in `cleanCode` method. [#257](https://github.com/adamgruber/mochawesome/issues/257)
 
-## [3.1.0] / 2018-10-17
+## [3.1.0] - 2018-10-17
 ### Changed
 - Invert logic for getting test code by checking for `test.body` before `test.fn` inside `cleanTest` method [#252](https://github.com/adamgruber/mochawesome/issues/252)
 
-## [3.0.3] / 2018-07-25
+## [3.0.3] - 2018-07-25
 ### Changed
 - Reworked `cleanCode` regexes to handle more cases [#244](https://github.com/adamgruber/mochawesome/issues/244)
 
-## [3.0.2] / 2018-01-25
+## [3.0.2] - 2018-01-25
 ### Changed
 - Call `stripAnsi` for test/suite titles. [#223](https://github.com/adamgruber/mochawesome/pull/223) (@JoeTheFkingFrypan)
 
-## [3.0.1] / 2017-12-26
+## [3.0.1] - 2017-12-26
 ### Fixed
 - Updated RegExp in `cleanCode` method to handle arrow functions without braces. [#220](https://github.com/adamgruber/mochawesome/issues/220)
 
-## [3.0.0] / 2017-11-30
+## [3.0.0] - 2017-11-30
 This release is in tandem with and requires mochawesome-report-generator >= 3.0.0.
 
 ### Added

--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -1,8 +1,8 @@
 const Base = require('mocha/lib/reporters/base');
 const Spec = require('mocha/lib/reporters/spec');
 const uuid = require('uuid');
-const conf = require('./config');
 const marge = require('mochawesome-report-generator');
+const conf = require('./config');
 const utils = require('./utils');
 
 // Import the utility functions

--- a/src/utils.js
+++ b/src/utils.js
@@ -225,7 +225,7 @@ function cleanSuite(suite, totalTestsRegistered, config) {
     suite.tests,
     test => {
       const cleanedTest = cleanTest(test, config);
-      duration += test.duration;
+      duration += test.duration || 0;
       if (cleanedTest.state === 'passed') passingTests.push(cleanedTest.uuid);
       if (cleanedTest.state === 'failed') failingTests.push(cleanedTest.uuid);
       if (cleanedTest.pending) pendingTests.push(cleanedTest.uuid);

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -1,4 +1,5 @@
 const Mocha = require('mocha');
+const createStatsCollector = require('mocha/lib/stats-collector');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const Assert = require('assert').AssertionError;
@@ -42,6 +43,7 @@ describe('Mochawesome Reporter', () => {
     subSuite = new Suite('Mochawesome Suite', 'root');
     suite.addSuite(subSuite);
     runner = new Runner(suite);
+    createStatsCollector(runner);
     mochaReporter = new mocha._reporter(runner, {
       reporterOptions: {
         quiet: true


### PR DESCRIPTION
**Issue**
Skipped tests do not have a duration which causes the total suite duration calculation to fail
```js
duration += test.duration // NaN when test.duration === undefined
```
**Solution**
Add conditional logic to handle when `test.duration` is `undefined`.

Fixes #276 