### PR TITLE
Allow overriding the console reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The options below are specific to the reporter. For a list of all available opti
 
 Option Name | Type | Default | Description
 :---------- | :--- | :------ | :----------
-`quiet` | boolean | false | Silence console messages and test report output
+`quiet` | boolean | false | Silence console messages
 `reportFilename` | string | mochawesome | Filename of saved report <br> *Applies to the generated html and json files.*
 `html` | boolean | true | Save the HTML output for the test run
 `json` | boolean | true | Save the JSON output for the test run

--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ The options below are specific to the reporter. For a list of all available opti
 
 Option Name | Type | Default | Description
 :---------- | :--- | :------ | :----------
-`quiet` | boolean | false | Silence console messages
+`quiet` | boolean | false | Silence console messages and test report output
 `reportFilename` | string | mochawesome | Filename of saved report <br> *Applies to the generated html and json files.*
 `html` | boolean | true | Save the HTML output for the test run
 `json` | boolean | true | Save the JSON output for the test run
+`consoleReporter` | string | spec | Name of mocha reporter to use for console output, or `none` to disable console report output entirely
 
 
 ### Adding Test Context

--- a/src/config.js
+++ b/src/config.js
@@ -35,6 +35,7 @@ module.exports = function (opts) {
     reportFilename: _getOption('reportFilename', reporterOpts, false, 'mochawesome'),
     saveHtml: _getOption('html', reporterOpts, true, true),
     saveJson: _getOption('json', reporterOpts, true, true),
+    consoleReporter: _getOption('consoleReporter', reporterOpts, false, 'spec'),
     useInlineDiffs: !!opts.useInlineDiffs
   };
 };

--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -105,8 +105,11 @@ function Mochawesome(runner, options) {
   // Call the Base mocha reporter
   Base.call(this, runner);
 
-  const ConsoleReporter = consoleReporter(this.config.consoleReporter);
-  new ConsoleReporter(runner); // eslint-disable-line
+  const reporterName = reporterOptions.consoleReporter;
+  if (!reporterOptions.quiet && reporterName !== 'none') {
+    const ConsoleReporter = consoleReporter(reporterName);
+    new ConsoleReporter(runner); // eslint-disable-line
+  }
 
   let endCalled = false;
 

--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -59,13 +59,16 @@ function done(output, options, config, failures, exit) {
  * @return {Object} Reporter class object
  */
 function consoleReporter(reporter) {
-  try {
-    // eslint-disable-next-line import/no-dynamic-require
-    return require(`mocha/lib/reporters/${reporter}`);
-  } catch (e) {
-    log(`Unknown console reporter '${reporter}', defaulting to spec`);
-    return require('mocha/lib/reporters/spec');
+  if (reporter) {
+    try {
+      // eslint-disable-next-line import/no-dynamic-require
+      return require(`mocha/lib/reporters/${reporter}`);
+    } catch (e) {
+      log(`Unknown console reporter '${reporter}', defaulting to spec`);
+    }
   }
+
+  return require('mocha/lib/reporters/spec');
 }
 
 /**
@@ -106,7 +109,7 @@ function Mochawesome(runner, options) {
   Base.call(this, runner);
 
   const reporterName = reporterOptions.consoleReporter;
-  if (!reporterOptions.quiet && reporterName !== 'none') {
+  if (reporterName !== 'none') {
     const ConsoleReporter = consoleReporter(reporterName);
     new ConsoleReporter(runner); // eslint-disable-line
   }

--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -1,5 +1,4 @@
 const Base = require('mocha/lib/reporters/base');
-const Spec = require('mocha/lib/reporters/spec');
 const mochaPkg = require('mocha/package.json');
 const uuid = require('uuid');
 const marge = require('mochawesome-report-generator');
@@ -49,6 +48,27 @@ function done(output, options, config, failures, exit) {
 }
 
 /**
+ * Get the class of the configured console reporter. This reporter outputs
+ * test results to the console while mocha is running, and before
+ * mochawesome generates its own report.
+ *
+ * Defaults to 'spec'.
+ *
+ * @param {String} reporter   Name of reporter to use for console output
+ *
+ * @return {Object} Reporter class object
+ */
+function consoleReporter(reporter) {
+  try {
+    // eslint-disable-next-line import/no-dynamic-require
+    return require(`mocha/lib/reporters/${reporter}`);
+  } catch (e) {
+    log(`Unknown console reporter '${reporter}', defaulting to spec`);
+    return require('mocha/lib/reporters/spec');
+  }
+}
+
+/**
  * Initialize a new reporter.
  *
  * @param {Runner} runner
@@ -85,8 +105,8 @@ function Mochawesome(runner, options) {
   // Call the Base mocha reporter
   Base.call(this, runner);
 
-  // Show the Spec Reporter in the console
-  new Spec(runner); // eslint-disable-line
+  const ConsoleReporter = consoleReporter(this.config.consoleReporter);
+  new ConsoleReporter(runner); // eslint-disable-line
 
   let endCalled = false;
 

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -243,12 +243,12 @@ describe('Mochawesome Reporter', () => {
           }
         });
         runner.run(failureCount => {
+          specStub.called.should.equal(true);
           mochaReporter.config.should.deepEqual(expected({
             consoleReporter: 'unknown'
           }));
           done();
         });
-        specStub.called.should.equal(true);
       });
 
       it('should allow overriding the console reporter', done => {
@@ -262,6 +262,38 @@ describe('Mochawesome Reporter', () => {
           nyanStub.called.should.equal(true);
           mochaReporter.config.should.deepEqual(expected({
             consoleReporter: 'nyan'
+          }));
+          done();
+        });
+      });
+
+      it('should disable the console reporter with the none reporter', done => {
+        specStub.reset();
+        mochaReporter = makeReporter({
+          reporterOptions: {
+            consoleReporter: 'none'
+          }
+        });
+        runner.run(failureCount => {
+          specStub.called.should.equal(false);
+          mochaReporter.config.should.deepEqual(expected({
+            consoleReporter: 'none'
+          }));
+          done();
+        });
+      });
+
+      it('should disable the console reporter with quiet option', done => {
+        specStub.reset();
+        mochaReporter = makeReporter({
+          reporterOptions: {
+            quiet: true
+          }
+        });
+        runner.run(failureCount => {
+          specStub.called.should.equal(false);
+          mochaReporter.config.should.deepEqual(expected({
+            quiet: true
           }));
           done();
         });

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -282,22 +282,6 @@ describe('Mochawesome Reporter', () => {
           done();
         });
       });
-
-      it('should disable the console reporter with quiet option', done => {
-        specStub.reset();
-        mochaReporter = makeReporter({
-          reporterOptions: {
-            quiet: true
-          }
-        });
-        runner.run(failureCount => {
-          specStub.called.should.equal(false);
-          mochaReporter.config.should.deepEqual(expected({
-            quiet: true
-          }));
-          done();
-        });
-      });
     });
   });
 

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -10,6 +10,8 @@ const makeTest = (title, doneFn) => new Test(title, doneFn);
 
 const reportStub = sinon.stub();
 const logStub = sinon.stub();
+const specStub = sinon.stub();
+const nyanStub = sinon.stub();
 
 utils.log = logStub;
 
@@ -18,14 +20,16 @@ const baseConfig = {
   reportFilename: 'mochawesome',
   saveHtml: true,
   saveJson: true,
-  useInlineDiffs: false
+  useInlineDiffs: false,
+  consoleReporter: 'spec'
 };
 
 const mochawesome = proxyquire('../src/mochawesome', {
   'mochawesome-report-generator': {
     create: reportStub
   },
-  'mocha/lib/reporters/spec': function Spec() {},
+  'mocha/lib/reporters/spec': specStub,
+  'mocha/lib/reporters/nyan': nyanStub,
   './utils': utils
 });
 
@@ -224,6 +228,40 @@ describe('Mochawesome Reporter', () => {
         runner.run(failureCount => {
           mochaReporter.config.should.deepEqual(expected({
             useInlineDiffs: true
+          }));
+          done();
+        });
+      });
+    });
+
+    describe('console reporter', () => {
+      it('should default to spec console reporter', done => {
+        specStub.reset();
+        mochaReporter = makeReporter({
+          reporterOptions: {
+            consoleReporter: 'unknown'
+          }
+        });
+        runner.run(failureCount => {
+          mochaReporter.config.should.deepEqual(expected({
+            consoleReporter: 'unknown'
+          }));
+          done();
+        });
+        specStub.called.should.equal(true);
+      });
+
+      it('should allow overriding the console reporter', done => {
+        nyanStub.reset();
+        mochaReporter = makeReporter({
+          reporterOptions: {
+            consoleReporter: 'nyan'
+          }
+        });
+        runner.run(failureCount => {
+          nyanStub.called.should.equal(true);
+          mochaReporter.config.should.deepEqual(expected({
+            consoleReporter: 'nyan'
           }));
           done();
         });


### PR DESCRIPTION
I wanted to be able to override the console reporter when using mochawesome, but found that this wasn't supported. This PR adds support for this feature via the `consoleReporter` reporter option.