### PR TITLE
fix: using `addContext` inside a `before` or `after` hook should work as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # mochawesome changelog
 
 ## [Unreleased]
+### Fixed
+- Issue where using `addContext` inside a `before` or `after` hook would incorrectly apply context to the test [#284](https://github.com/adamgruber/mochawesome/issues/284)
 
 ## [4.0.0] - 2019-06-04
 ### Changed

--- a/src/addContext.js
+++ b/src/addContext.js
@@ -83,10 +83,19 @@ const addContext = function (...args) {
   }
 
   /* Context is valid, now get the test object
-   * If `addContext` is called from inside a `beforeEach` or `afterEach`
-   * the test object will be `.currentTest`, otherwise just `.test`
+   * If `addContext` is called from inside a hook the test object
+   * will be `.currentTest`, and the hook will be `.test`.
+   * Otherwise the test is just `.test` and `.currentTest` is undefined.
    */
-  const test = args[0].currentTest || args[0].test;
+  const currentTest = args[0].currentTest;
+  const activeTest = args[0].test;
+
+  /* For `before` and `after`, add the context to the hook,
+   * otherwise add it to the actual test.
+   */
+  const isEachHook = currentTest
+    && /^"(?:before|after)\seach"/.test(activeTest.title);
+  const test = isEachHook ? currentTest : activeTest;
 
   if (!test) {
     log(ERRORS.INVALID_TEST, 'error');


### PR DESCRIPTION
Prior to mocha `6.0.0`, calling `addContext` in a `before` or `after` hook would correctly add the context to the hook object. However due to a change in mocha, the assumptions made inside `addContext` no longer held true. This is causing the context to be added to the tests instead of the hook. This PR fixes the behavior.

Alternate approach to #285. Uses a simple regex to determine if the hook is an `each` hook or not.