### PR TITLE
Fix for Mocha 6

### DIFF
--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -81,6 +81,16 @@ function Mochawesome(runner, options) {
   // Set the config options
   this.config = conf(options);
 
+  // If the runner doesn't have a stats object then we're probably
+  // running under Mocha 6 but were started in a way that didn't
+  // initialize the stats collector.  Attempt to remedy that here.
+  if (!runner.stats) {
+    const createStatsCollector = require('mocha/lib/stats-collector');
+    if (typeof createStatsCollector === 'function') {
+      createStatsCollector(runner);
+    }
+  }
+
   // Reporter options
   const reporterOptions = Object.assign(
     {},


### PR DESCRIPTION
Mocha 6 introduced a new "stats-collector" that has to be instantiated
in order to get stats.  If you are using Mocha itself directly this
works fine, but a lot of things that are running Mocha
programatically, or overriding `Mocha.prototype.run` still haven't got
this right yet (Cypress is the big one for me).

Ideally this would be the frameworks problem to fix, but since it's
relatively simple to make Mochawesome work regardless of whether the
runner initialized correctly, I thought you might be interested.

fixes #269
fixes #282