### PR TITLE
Ensure stats collector is initialized

### DIFF
--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -81,6 +81,12 @@ function Mochawesome(runner, options) {
   // Set the config options
   this.config = conf(options);
 
+  // Ensure stats collector has been initialized
+  if (!runner.stats) {
+    const createStatsCollector = require('mocha/lib/stats-collector');
+    createStatsCollector(runner);
+  }
+
   // Reporter options
   const reporterOptions = {
     ...options.reporterOptions,

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -12,6 +12,7 @@ const reportStub = sinon.stub();
 const logStub = sinon.stub();
 const specStub = sinon.stub();
 const nyanStub = sinon.stub();
+const statsCollectorStub = sinon.stub();
 
 utils.log = logStub;
 
@@ -30,6 +31,7 @@ const mochawesome = proxyquire('../src/mochawesome', {
   },
   'mocha/lib/reporters/spec': specStub,
   'mocha/lib/reporters/nyan': nyanStub,
+  'mocha/lib/stats-collector': statsCollectorStub,
   './utils': utils
 });
 
@@ -51,6 +53,21 @@ describe('Mochawesome Reporter', () => {
       reporterOptions: {
         quiet: true
       }
+    });
+  });
+
+  describe('Stats Collector', () => {
+    beforeEach(() => {
+      delete runner.stats;
+      mochaReporter = new mocha._reporter(runner, {
+        reporterOptions: {
+          quiet: true
+        }
+      });
+    });
+
+    it('should initialize stats collector', () => {
+      statsCollectorStub.called.should.equal(true);
     });
   });
 


### PR DESCRIPTION
When run under certain conditions, the stats collector may not be
initialized. For example, when used with Cypress.

