### PR TITLE
Add register.js file into the package root

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "main": "src/mochawesome.js",
   "files": [
     "addContext.js",
+    "register.js",
     "src"
   ],
   "nyc": {


### PR DESCRIPTION
Purposes:
- to add `register.js` into the package root in order to fix the `--require mochawesome/register` hook.

Currently it works via `--require mochawesome/src/register` 