### PR TITLE
Calculate skipped totals while cleaning suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # mochawesome changelog
 
 ## [Unreleased]
+### Changed
+- Update how the total number of skipped tests is calculated [#317](https://github.com/adamgruber/mochawesome/issues/317)
 
 ## [6.2.2] - 2021-02-16
 ### Changed
@@ -273,7 +275,8 @@ This release is in tandem with and requires mochawesome-report-generator >= 3.0.
 - Custom font-icon set
 - All fonts are now local to the report
 
-[Unreleased]: https://github.com/adamgruber/mochawesome/compare/6.2.1...HEAD
+[Unreleased]: https://github.com/adamgruber/mochawesome/compare/6.2.2...HEAD
+[6.2.2]: https://github.com/adamgruber/mochawesome/compare/6.2.1...6.2.2
 [6.2.1]: https://github.com/adamgruber/mochawesome/compare/6.2.0...6.2.1
 [6.2.0]: https://github.com/adamgruber/mochawesome/compare/6.1.1...6.2.0
 [6.1.1]: https://github.com/adamgruber/mochawesome/compare/6.1.0...6.1.1

--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -20,8 +20,11 @@ const {
 // Import the utility functions
 const { log, mapSuites } = utils;
 
-// Track the total number of tests registered
-const totalTestsRegistered = { total: 0 };
+// Track the total number of tests registered/skipped
+const testTotals = {
+  registered: 0,
+  skipped: 0
+}
 
 /**
  * Done function gets called before mocha exits
@@ -107,8 +110,9 @@ function Mochawesome(runner, options) {
   this.done = (failures, exit) =>
     done(this.output, reporterOptions, this.config, failures, exit);
 
-  // Reset total tests counter
-  totalTestsRegistered.total = 0;
+  // Reset total tests counters
+  testTotals.registered = 0;
+  testTotals.skipped = 0;
 
   // Call the Base mocha reporter
   Base.call(this, runner);
@@ -202,7 +206,7 @@ function Mochawesome(runner, options) {
 
         const rootSuite = mapSuites(
           this.runner.suite,
-          totalTestsRegistered,
+          testTotals,
           this.config
         );
 
@@ -224,7 +228,7 @@ function Mochawesome(runner, options) {
           },
         };
 
-        obj.stats.testsRegistered = totalTestsRegistered.total;
+        obj.stats.testsRegistered = testTotals.registered;
 
         const { passes, failures, pending, tests, testsRegistered } = obj.stats;
         const passPercentage = (passes / (testsRegistered - pending)) * 100;
@@ -234,7 +238,7 @@ function Mochawesome(runner, options) {
         obj.stats.pendingPercent = pendingPercentage;
         obj.stats.other = passes + failures + pending - tests; // Failed hooks
         obj.stats.hasOther = obj.stats.other > 0;
-        obj.stats.skipped = testsRegistered - tests;
+        obj.stats.skipped = testTotals.skipped;
         obj.stats.hasSkipped = obj.stats.skipped > 0;
         obj.stats.failures -= obj.stats.other;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -192,12 +192,13 @@ function cleanTest(test, config) {
  * Return a plain-object representation of `suite` with additional properties for rendering.
  *
  * @param {Object} suite
- * @param {Object} totalTestsRegistered
- * @param {Integer} totalTestsRegistered.total
+ * @param {Object} testTotals  Cumulative count of tests registered/skipped
+ * @param {Integer} testTotals.registered
+ * @param {Integer} testTotals.skipped
  *
  * @return {Object|boolean} cleaned suite or false if suite is empty
  */
-function cleanSuite(suite, totalTestsRegistered, config) {
+function cleanSuite(suite, testTotals, config) {
   let duration = 0;
   const passingTests = [];
   const failingTests = [];
@@ -222,7 +223,8 @@ function cleanSuite(suite, totalTestsRegistered, config) {
     return cleanedTest;
   });
 
-  totalTestsRegistered.total += tests.length;
+  testTotals.registered += tests.length;
+  testTotals.skipped += skippedTests.length;
 
   const cleaned = {
     uuid: suite.uuid || /* istanbul ignore next: default */ uuid.v4(),
@@ -257,20 +259,21 @@ function cleanSuite(suite, totalTestsRegistered, config) {
  * and recursively cleaning any nested suites.
  *
  * @param {Object} suite          Suite to map over
- * @param {Object} totalTestsReg  Cumulative count of total tests registered
- * @param {Integer} totalTestsReg.total
+ * @param {Object} testTotals  Cumulative count of tests registered/skipped
+ * @param {Integer} testTotals.registered
+ * @param {Integer} testTotals.skipped
  * @param {Object} config         Reporter configuration
  */
-function mapSuites(suite, totalTestsReg, config) {
+function mapSuites(suite, testTotals, config) {
   const suites = suite.suites.reduce((acc, subSuite) => {
-    const mappedSuites = mapSuites(subSuite, totalTestsReg, config);
+    const mappedSuites = mapSuites(subSuite, testTotals, config);
     if (mappedSuites) {
       acc.push(mappedSuites);
     }
     return acc;
   }, []);
   const toBeCleaned = { ...suite, suites };
-  return cleanSuite(toBeCleaned, totalTestsReg, config);
+  return cleanSuite(toBeCleaned, testTotals, config);
 }
 
 module.exports = {


### PR DESCRIPTION
In some edge cases the previous calculation of skipped tests was
not accurate. This change ensures a consistent skip count by using
the `skipped` arrays in each suite to get the total.

#317 