### PR TITLE
Changing the processing of parallel events

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
     - run: |
-        npm install
-        npm install react react-dom
+        npm ci
         npm run build --if-present
         npm test
       env:

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Since `mocha@8` test files can be run in parallel using the `--parallel` flag. I
 
 `mocha tests --reporter mochawesome --require mochawesome/register`
 
-> Due to differences in how parallel tests are processed, statistics may differ between sequential and parallel test runs. Mocha does not provide information about skipped tests in parallel mode. For more information, see https://mochajs.org/#parallel-tests.
-
 ### Output
 
 Mochawesome generates the following inside your project directory:

--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -7,7 +7,7 @@ const conf = require('./config');
 const utils = require('./utils');
 const pkg = require('../package.json');
 const Mocha = require('mocha');
-const { EVENT_SUITE_BEGIN } = Mocha.Runner.constants;
+const { EVENT_SUITE_END } = Mocha.Runner.constants;
 
 // Import the utility functions
 const { log, mapSuites } = utils;
@@ -140,10 +140,10 @@ function Mochawesome(runner, options) {
       suite.suites.forEach(it => setSuiteDefaults(it));
     };
 
-    runner.on(EVENT_SUITE_BEGIN, function (suite) {
+    runner.on(EVENT_SUITE_END, function (suite) {
       if (suite.root) {
         setSuiteDefaults(suite);
-        suite.suites.forEach(it => runner.suite.suites.push(it));
+        runner.suite.suites.push(...suite.suites)
       }
     });
   }

--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -7,15 +7,7 @@ const conf = require('./config');
 const utils = require('./utils');
 const pkg = require('../package.json');
 const Mocha = require('mocha');
-const {
-  EVENT_RUN_BEGIN,
-  EVENT_HOOK_END,
-  EVENT_SUITE_BEGIN,
-  EVENT_TEST_PASS,
-  EVENT_TEST_FAIL,
-  EVENT_TEST_PENDING,
-  EVENT_SUITE_END,
-} = Mocha.Runner.constants;
+const { EVENT_SUITE_BEGIN } = Mocha.Runner.constants;
 
 // Import the utility functions
 const { log, mapSuites } = utils;
@@ -134,64 +126,25 @@ function Mochawesome(runner, options) {
 
   // Handle events from workers in parallel mode
   if (runner.constructor.name === 'ParallelBufferedRunner') {
-    let currentSuite;
-
-    const HookMap = {
-      ['"before all" ']: '_beforeAll',
-      ['"before each" ']: '_beforeEach',
-      ['"after each" ']: '_afterEach',
-      ['"after all" ']: '_afterAll',
+    const setSuiteDefaults = suite => {
+      [
+        'suites',
+        'tests',
+        '_beforeAll',
+        '_beforeEach',
+        '_afterEach',
+        '_afterAll',
+      ].forEach(field => {
+        suite[field] = suite[field] || [];
+      });
+      suite.suites.forEach(it => setSuiteDefaults(it));
     };
 
-    runner.on(EVENT_RUN_BEGIN, function () {
-      currentSuite = undefined;
-    });
-
     runner.on(EVENT_SUITE_BEGIN, function (suite) {
-      suite._beforeAll = suite._beforeAll || [];
-      suite._beforeEach = suite._beforeEach || [];
-      suite.suites = suite.suites || [];
-      suite.tests = suite.tests || [];
-      suite._afterEach = suite._afterEach || [];
-      suite._afterAll = suite._afterAll || [];
       if (suite.root) {
-        suite = runner.suite;
-      } else if (currentSuite) {
-        currentSuite.suites.push(suite);
-        suite.parent = currentSuite;
+        setSuiteDefaults(suite);
+        suite.suites.forEach(it => runner.suite.suites.push(it));
       }
-      currentSuite = suite;
-    });
-
-    runner.on(EVENT_SUITE_END, function () {
-      if (currentSuite) {
-        currentSuite = currentSuite.parent;
-      }
-    });
-
-    runner.on(EVENT_HOOK_END, function (hook) {
-      if (currentSuite) {
-        const hooks = currentSuite[HookMap[hook.title.split('hook')[0]]];
-        // add only once, since it is attached to the Suite
-        if (hooks && hooks.every(it => it.title !== hook.title)) {
-          hook.parent = currentSuite;
-          hooks.push(hook);
-        }
-      }
-    });
-
-    [EVENT_TEST_PASS, EVENT_TEST_FAIL, EVENT_TEST_PENDING].forEach(type => {
-      runner.on(type, function (test) {
-        if (currentSuite) {
-          test.parent = currentSuite;
-          if (test.type === 'hook') {
-            const hooks = currentSuite[HookMap[test.title.split('hook')[0]]];
-            hooks && hooks.push(test);
-          } else {
-            currentSuite.tests.push(test);
-          }
-        }
-      });
     });
   }
 

--- a/src/register.js
+++ b/src/register.js
@@ -3,16 +3,64 @@ const Mocha = require('mocha');
 const extendSerialize = (target, fields) => {
   const serialize = target.serialize;
   target.serialize = function (...args) {
+    /* The full state is required only once during the EVENT_SUITE_BEGIN event.
+      So, we have to restore the original method to minimize the transmission over IPC.
+      The original method is used to provide the necessary data to mocha reporters.
+      Otherwise, the serialized data will be twice as large.
+      The trick here is to restore method in the instance, not in the prototype. */
+    this.serialize = serialize;
     const result = serialize.call(this, ...args);
     for (let field of fields) {
-      result[field] = this[field];
+      // The field's started with `$$` are results of methods
+      let value = field.startsWith('$$') ? this[field.slice(2)]() : this[field];
+      if (value != null) {
+        if (Array.isArray(value)) {
+          value = value.map(it =>
+            typeof it.serialize === 'function' ? it.serialize(...args) : it
+          );
+        }
+        result[field] = value;
+      }
+    }
+    if (result.err instanceof Error) {
+      result.err = serializeError(result.err);
     }
     return result;
   };
 };
 
-extendSerialize(Mocha.Suite.prototype, ['file']);
-extendSerialize(Mocha.Hook.prototype, ['body', 'state']);
+const serializeError = error => {
+  /* The default properties of Error class: name, message and stack; are excluded from the enumeration.
+     It causes the following: JSON.stringify(new Error("FAKE")) === '{}'
+     So, we need to provide explicitly these properties to the JSON serializer. */
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      stack: error.stack,
+      name: error.name,
+      ...error,
+    };
+  }
+  return error;
+};
+
+// Serialize the full root suite state to count `Skipped` tests.
+extendSerialize(Mocha.Suite.prototype, [
+  'file',
+  'suites',
+  'tests',
+  '_beforeAll',
+  '_beforeEach',
+  '_afterEach',
+  '_afterAll',
+]);
+extendSerialize(Mocha.Hook.prototype, [
+  'body',
+  'state',
+  'err',
+  'context',
+  '$$fullTitle',
+]);
 extendSerialize(Mocha.Test.prototype, ['pending', 'context']);
 
 module.exports = {};

--- a/test/parallel-mode.test.js
+++ b/test/parallel-mode.test.js
@@ -1,4 +1,4 @@
-require('../src/register');
+const { serializeSuite, serializeHook, serializeTest, serializeError } = require('../src/register');
 const Mochawesome = require('../src/mochawesome');
 const { EventEmitter } = require('events');
 const Mocha = require('mocha');
@@ -9,144 +9,246 @@ describe('Parallel Mode', () => {
   const noop = () => {};
 
   describe("Mocha's worker", () => {
-    [
-      ['file', '/test/test.js'],
-      ['suites', [new Suite('FAKE SUB-SUITE')]],
-      ['tests', [new Test('FAKE TEST')]],
-      ['_beforeAll', [new Hook('FAKE BEFORE_ALL HOOK')]],
-      ['_beforeEach', [new Hook('FAKE BEFORE_EACH HOOK')]],
-      ['_afterEach', [new Hook('FAKE AFTER_EACH HOOK')]],
-      ['_afterAll', [new Hook('FAKE AFTER_ALL HOOK')]],
-    ].forEach(([field, expected]) => {
-      const withParent = (parent, item) => {
-        return Array.isArray(item)
-          ? item.map(it => {
-              it.parent = parent;
-              return it;
-            })
-          : item;
+    describe("Mocha.Suite.serialize()", () => {
+      const createSuite = function (name, isRoot) {
+        const suite = new Suite(name, {}, isRoot);
+        suite.beforeAll(() => console.log("beforeAll"));
+        suite.beforeEach(() => console.log("beforeEach"));
+        suite.addTest(new Test(name + ": FAKE TEST"))
+        suite.afterEach(() => console.log("afterEach"));
+        suite.afterAll(() => console.log("afterAll"));
+        return suite;
       };
-      const pick = (name, source) => source.map(it => it[name]);
 
-      it(`should serialize the suite's ${field}`, () => {
+      it(`should serialize the root suite's fully with all sub suites`, () => {
         // arrange
-        const given = { suiteName: 'FAKE SUITE' };
-        const suite = new Suite(given.suiteName);
-        suite[field] = withParent(suite, expected);
+        const given = { suiteName: 'FAKE ROOT SUITE', subSuiteName: 'FAKE SUB SUITE' };
+        const suite = createSuite(given.suiteName, true);
+        suite.addSuite(createSuite(given.subSuiteName, false));
 
         // act
-        const actual = suite.serialize()[field];
+        const actual = suite.serialize();
 
         // assert
-        if (Array.isArray(expected)) {
-          pick('title', actual).should.deepEqual(pick('title', expected));
-        } else {
-          actual.should.equal(expected);
-        }
+        actual.should.be.ok();
+        const dumpSuite = (suite) => ({
+          title: suite.title,
+          suites: suite.suites.map(it => dumpSuite(it)),
+          tests: suite.tests.map(it => ({ title: it.title })),
+          _beforeAll: suite._beforeAll.map(it => ({ title: it.title })),
+          _beforeEach: suite._beforeEach.map(it => ({ title: it.title })),
+          _afterEach: suite._afterEach.map(it => ({ title: it.title })),
+          _afterAll: suite._afterAll.map(it => ({ title: it.title })),
+        });
+        actual.should.containDeep(dumpSuite(suite));
+      });
+
+      it(`should serialize the suite's shallowly`, () => {
+        // arrange
+        const given = { suiteName: 'FAKE SUITE', subSuiteName: 'FAKE SUB SUITE' };
+        const suite = createSuite(given.suiteName, false);
+        suite.addSuite(createSuite(given.subSuiteName, false));
+
+        // act
+        const actual = suite.serialize();
+
+        // assert
+        actual.should.be.ok();
+        actual.should.containDeep({
+          root: false,
+          title: suite.title,
+          suites: undefined,
+          tests: undefined,
+          _beforeAll: undefined,
+          _beforeEach: undefined,
+          _afterEach: undefined,
+          _afterAll: undefined,
+        });
       });
     });
 
-    [
-      ['body', '() => console.log(a)'],
-      ['state', 'failed'],
-      ['context', 'https://example.com'],
-    ].forEach(([field, expected]) => {
-      it(`should serialize the hook's ${field}`, () => {
+    describe("serializeSuite()", () => {
+      [ true, false ].forEach(isRoot => {
+        [
+          isRoot ? [] : ['file', '/test/test.js'],
+          ['suites', [new Suite('FAKE SUB-SUITE')]],
+          ['tests', [new Test('FAKE TEST')]],
+          ['_beforeAll', [new Hook('FAKE BEFORE_ALL HOOK')]],
+          ['_beforeEach', [new Hook('FAKE BEFORE_EACH HOOK')]],
+          ['_afterEach', [new Hook('FAKE AFTER_EACH HOOK')]],
+          ['_afterAll', [new Hook('FAKE AFTER_ALL HOOK')]],
+        ].forEach(([field, expected]) => {
+          if (!field) return;
+
+          const withParent = (parent, item) => {
+            return Array.isArray(item)
+              ? item.map(it => {
+                  it.parent = parent;
+                  return it;
+                })
+              : item;
+          };
+          const pick = (name, source) => source.map(it => it[name]);
+
+          it(`should serialize the suite's ${field}`, () => {
+            // arrange
+            const given = { suiteName: 'FAKE SUITE' };
+            const suite = new Suite(given.suiteName, {}, isRoot);
+            suite[field] = withParent(suite, expected);
+
+            // act
+            const actual = serializeSuite(suite)[field];
+
+            // assert
+            if (Array.isArray(expected)) {
+              pick('title', actual).should.deepEqual(pick('title', expected));
+            } else {
+              actual.should.equal(expected);
+            }
+          });
+        });
+      });
+    });
+
+    describe("serializeHook()", () => {
+      [
+        ['body', '() => console.log(a)'],
+        ['state', 'failed'],
+        ['context', 'https://example.com'],
+      ].forEach(([field, expected]) => {
+        it(`should serialize the hook's ${field}`, () => {
+          // arrange
+          const given = { hookName: 'FAKE HOOK' };
+          const hook = new Hook(given.hookName, noop);
+          hook.parent = new Suite('FAKE SUITE');
+          hook[field] = expected;
+
+          // act
+          const actual = serializeHook(hook);
+
+          // assert
+          actual.title.should.equal(given.hookName);
+          actual[field].should.equal(expected);
+        });
+      });
+
+      it(`should serialize the hook's full title`, () => {
         // arrange
-        const given = { hookName: 'FAKE HOOK' };
+        const given = { hookName: 'FAKE HOOK', suiteName: 'FAKE SUITE' };
         const hook = new Hook(given.hookName, noop);
-        hook.parent = new Suite('FAKE SUITE');
-        hook[field] = expected;
+        hook.parent = new Suite(given.suiteName);
 
         // act
-        const actual = hook.serialize();
+        const actual = serializeHook(hook)["$$fullTitle"];
 
         // assert
-        actual.title.should.equal(given.hookName);
-        actual[field].should.equal(expected);
+        actual.should.equal(hook.fullTitle());
+        actual.should.equal([ given.suiteName, given.hookName ].join(' '));
       });
-    });
 
-    it(`should serialize the hook's full title`, () => {
-      // arrange
-      const given = { hookName: 'FAKE HOOK', suiteName: 'FAKE SUITE' };
-      const hook = new Hook(given.hookName, noop);
-      hook.parent = new Suite(given.suiteName);
-
-      // act
-      const actual = hook.serialize()["$$fullTitle"];
-
-      // assert
-      actual.should.equal(hook.fullTitle());
-      actual.should.equal([ given.suiteName, given.hookName ].join(' '));
-    });
-
-    it(`should serialize the hook's err`, () => {
-      // arrange
-      const given = {
-        hookName: 'FAKE HOOK',
-        suiteName: 'FAKE SUITE',
-        error: Object.assign(new Error("FAKE ERROR"), { fake: true })
-      };
-      const hook = new Hook(given.hookName, noop);
-      hook.parent = new Suite(given.suiteName);
-      hook.err = given.error;
-
-      // act
-      const actual = hook.serialize()["err"];
-
-      // assert
-      actual.should.not.equal(given.error);
-      actual.should.deepEqual({
-        name: given.error.name,
-        message: given.error.message,
-        stack: given.error.stack,
-        fake: true
-      });
-    });
-
-    [
-      ['context', 'FAKE CONTEXT'],
-      ['pending', Math.random() > 0.5],
-    ].forEach(([field, expected]) => {
-      it(`should serialize the test's ${field}`, () => {
+      it(`should serialize the hook's err`, () => {
         // arrange
-        const given = { testName: 'FAKE TEST' };
-        const test = new Test(given.testName, noop);
-        test.parent = new Suite('FAKE SUITE');
-        test[field] = expected;
+        const given = {
+          hookName: 'FAKE HOOK',
+          suiteName: 'FAKE SUITE',
+          error: Object.assign(new Error("FAKE ERROR"), { fake: true })
+        };
+        const hook = new Hook(given.hookName, noop);
+        hook.parent = new Suite(given.suiteName);
+        hook.err = given.error;
 
         // act
-        const actual = test.serialize();
+        const actual = serializeHook(hook)["err"];
 
         // assert
-        actual.type.should.equal('test');
-        actual.title.should.equal(given.testName);
-        actual[field].should.equal(expected);
+        actual.should.not.equal(given.error);
+        actual.should.deepEqual({
+          name: given.error.name,
+          message: given.error.message,
+          stack: given.error.stack,
+          fake: true
+        });
       });
     });
 
-    it(`should serialize the test's err`, () => {
-      // arrange
-      const given = {
-        testName: 'FAKE TEST',
-        suiteName: 'FAKE SUITE',
-        error: Object.assign(new Error("FAKE ERROR"), { fake: true })
-      };
-      const test = new Test(given.testName, noop);
-      test.parent = new Suite(given.suiteName);
-      test.err = given.error;
+    describe("serializeTest()", () => {
+      [
+        ['context', 'FAKE CONTEXT'],
+        ['pending', Math.random() > 0.5],
+      ].forEach(([field, expected]) => {
+        it(`should serialize the test's ${field}`, () => {
+          // arrange
+          const given = { testName: 'FAKE TEST' };
+          const test = new Test(given.testName, noop);
+          test.parent = new Suite('FAKE SUITE');
+          test[field] = expected;
 
-      // act
-      const actual = test.serialize()["err"];
+          // act
+          const actual = serializeTest(test);
 
-      // assert
-      actual.should.not.equal(given.error);
-      actual.should.deepEqual({
-        name: given.error.name,
-        message: given.error.message,
-        stack: given.error.stack,
-        fake: true
+          // assert
+          actual.type.should.equal('test');
+          actual.title.should.equal(given.testName);
+          actual[field].should.equal(expected);
+        });
+      });
+
+      it(`should serialize the test's err`, () => {
+        // arrange
+        const given = {
+          testName: 'FAKE TEST',
+          suiteName: 'FAKE SUITE',
+          error: Object.assign(new Error("FAKE ERROR"), { fake: true })
+        };
+        const test = new Test(given.testName, noop);
+        test.parent = new Suite(given.suiteName);
+        test.err = given.error;
+
+        // act
+        const actual = serializeTest(test)["err"];
+
+        // assert
+        actual.should.not.equal(given.error);
+        actual.should.deepEqual({
+          name: given.error.name,
+          message: given.error.message,
+          stack: given.error.stack,
+          fake: true
+        });
+      });
+    });
+
+    describe("serializeError()", () => {
+      it(`should serialize the instance of Error`, () => {
+        // arrange
+        const given = {
+          error: Object.assign(new Error("FAKE ERROR"), { fake: true })
+        };
+
+        // act
+        const actual = serializeError(given.error);
+
+        // assert
+        actual.should.not.equal(given.error);
+        actual.should.deepEqual({
+          name: given.error.name,
+          message: given.error.message,
+          stack: given.error.stack,
+          fake: true
+        });
+      });
+
+      it(`should return the same object if it isn't the instance of Error`, () => {
+        // arrange
+        const given = {
+          error: { message: "FAKE ERROR", fake: true }
+        };
+
+        // act
+        const actual = serializeError(given.error);
+
+        // assert
+        actual.should.equal(given.error);
       });
     });
   });
@@ -215,7 +317,7 @@ describe('Parallel Mode', () => {
 
       // act
       runner.emit(constants.EVENT_RUN_BEGIN);
-      runner.emit(constants.EVENT_SUITE_BEGIN, rootSuite);
+      runner.emit(constants.EVENT_SUITE_END, rootSuite);
       runner.emit(constants.EVENT_RUN_END);
 
       // assert


### PR DESCRIPTION
Purposes:
- to make the same report with parallel mode as the report with sync mode

@juergba suggested to serialize tests in suites and listen to EVENT_SUITE_END event: https://github.com/adamgruber/mochawesome/pull/331#issuecomment-915360174
This should allow to calculate the correct amount of SKIPPED tests.

I have tried to set `runner.linkPartialObjects(true)` and listen the EVENT_SUITE_END to recreate the suite's tree. It does not work for the nested suites if any hooks failed in the parent suite.
Thus, the only solution was to make a full dump of the root suite and listen it in the EVENT_SUITE_END event.
The disadvantage of this is that a full dump is created twice for the EVENT_SUITE_BEGIN and EVENT_SUITE_AND events, which increases data transfer via IPC by 25%. For comparison, I have used `test-functional` tests, and the data transfer is 22.17 MB, when if a full dump was made once, it would be 27.04 MB.

In additional:
- fixed the error serialization

Unrelated changes:
- used `npm ci` instead of `npm install`
- used `actions/setup-node@v2` with `cache: 'npm'` option