### PR TITLE
fix: replace uuid dependency with native crypto.randomUUID()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "lodash.isobject": "^3.0.2",
         "lodash.isstring": "^4.0.1",
         "mochawesome-report-generator": "^6.3.0",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^8.3.2"
+        "strip-ansi": "^6.0.1"
       },
       "devDependencies": {
         "cross-env": "^7.0.3",
@@ -4176,14 +4175,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
@@ -7700,11 +7691,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "lodash.isobject": "^3.0.2",
     "lodash.isstring": "^4.0.1",
     "mochawesome-report-generator": "^6.3.0",
-    "strip-ansi": "^6.0.1",
-    "uuid": "^8.3.2"
+    "strip-ansi": "^6.0.1"
   },
   "peerDependencies": {
     "mocha": ">=7"

--- a/src/mochawesome.js
+++ b/src/mochawesome.js
@@ -1,6 +1,6 @@
 const Base = require('mocha/lib/reporters/base');
 const mochaPkg = require('mocha/package.json');
-const uuid = require('uuid');
+const { randomUUID } = require('crypto');
 const marge = require('mochawesome-report-generator');
 const margePkg = require('mochawesome-report-generator/package.json');
 const conf = require('./config');
@@ -120,7 +120,7 @@ function Mochawesome(runner, options) {
   // Add a unique identifier to each suite/test/hook
   ['suite', 'test', 'hook', 'pending'].forEach(type => {
     runner.on(type, item => {
-      item.uuid = uuid.v4();
+      item.uuid = randomUUID();
     });
   });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ const isString = require('lodash.isstring');
 const isFunction = require('lodash.isfunction');
 const isEmpty = require('lodash.isempty');
 const chalk = require('chalk');
-const uuid = require('uuid');
+const { randomUUID } = require('crypto');
 const mochaUtils = require('mocha/lib/utils');
 const stringify = require('json-stringify-safe');
 const diff = require('diff');
@@ -177,7 +177,7 @@ function cleanTest(test, config) {
     context: stringify(test.context, null, 2),
     code: code && cleanCode(code),
     err: (test.err && normalizeErr(test.err, config)) || {},
-    uuid: test.uuid || /* istanbul ignore next: default */ uuid.v4(),
+    uuid: test.uuid || /* istanbul ignore next: default */ randomUUID(),
     parentUUID: test.parent && test.parent.uuid,
     isHook: test.type === 'hook',
   };
@@ -227,7 +227,7 @@ function cleanSuite(suite, testTotals, config) {
   testTotals.skipped += skippedTests.length;
 
   const cleaned = {
-    uuid: suite.uuid || /* istanbul ignore next: default */ uuid.v4(),
+    uuid: suite.uuid || /* istanbul ignore next: default */ randomUUID(),
     title: stripAnsi(suite.title),
     fullFile: suite.file || '',
     file: suite.file ? suite.file.replace(process.cwd(), '') : '',

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -4,7 +4,7 @@ const sampleTests = require('./sample-tests');
 const sampleSuite = require('./sample-suite');
 
 const utils = proxyquire('../src/utils', {
-  uuid: { v4: () => 'fc3f8bee-4feb-4f28-8e27-a680704c9176' },
+  crypto: { randomUUID: () => 'fc3f8bee-4feb-4f28-8e27-a680704c9176' },
 });
 
 const { log, cleanCode, cleanTest, cleanSuite } = utils;


### PR DESCRIPTION
## Problem

   The `mochawesome` package depends on the `uuid` npm package (`^8.3.2`) to generate UUIDs for
   test/suite/hook identifiers. This introduces an unnecessary third-party dependency — Node.js has
   provided `crypto.randomUUID()` natively since **v14.17.0 / 15.6.0**, which is well within the
   supported engine range of this library.

   ## Solution

   Replace `uuid` with Node.js's built-in `crypto.randomUUID()` and remove the `uuid` package entirely.

   ## Changes

   | File | Change |
   |---|---|
   | `src/mochawesome.js` | Replace `require('uuid')` with `const { randomUUID } = require('crypto')`, use `randomUUID()` instead of `uuid.v4()`|
   | `src/utils.js` | Same replacement in `cleanTest()` and `cleanSuite()` |
   | `test/utils.test.js` | Update `proxyquire` mock from `uuid` module to `crypto` module |
   | `package.json` / `package-lock.json` | Remove `uuid` dependency |

   ## Before / After

   ```js
   // Before
   const uuid = require('uuid');
   item.uuid = uuid.v4();

   // After
   const { randomUUID } = require('crypto');
   item.uuid = randomUUID();
```

  Notes

   - No behavior change — crypto.randomUUID() produces RFC 4122 v4 UUIDs, same as uuid.v4()
   - All existing tests pass

  Closes #412 