### PR TITLE
ci: publish before pushing git state; fix repository.url warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,19 +59,22 @@ jobs:
           cat "${{ steps.notes.outputs.file }}"
           npm publish --provenance --dry-run
 
-      - name: Commit, tag, push, publish, release
+      - name: Publish, then commit/tag/push and release
         if: ${{ github.event.inputs.dry-run != 'true' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Publish first: it's the step most likely to fail (auth) and the only
+          # irreversible one. If it fails, nothing has been committed/tagged/
+          # pushed, so a re-run starts from a clean tree.
+          npm publish --provenance
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add package.json package-lock.json CHANGELOG.md
           git commit -m "release: ${{ steps.version.outputs.tag }}"
           git tag "${{ steps.version.outputs.tag }}"
           git push --follow-tags origin main
-          npm publish --provenance
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
             --notes-file "${{ steps.notes.outputs.file }}"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adamgruber/mochawesome"
+    "url": "git+https://github.com/adamgruber/mochawesome.git"
   },
   "keywords": [
     "mocha",


### PR DESCRIPTION
Follow-ups from the v8.0.0 release dry run.

## Publish before pushing git state
Reorders the release step so `npm publish --provenance` runs **before** the commit/tag/push. Publish is the only irreversible step and the one most likely to fail (bad/expired `NPM_TOKEN`). Old order pushed the bump+tag first, so a token failure left `main` bumped/tagged with nothing on npm — recoverable but manual. New order: an auth failure leaves the working tree clean, so a re-run just starts over.

## Fix repository.url warning
The dry run logged:
```
npm warn publish "repository.url" was normalized to "git+https://github.com/adamgruber/mochawesome.git"
```
Sets `repository.url` to the normalized form to silence it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)