### PR TITLE
ci: fix release tag (bare version, annotated, pushed)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         id: version
         run: |
           NEW=$(npm version "${{ github.event.inputs.version }}" --no-git-tag-version)
-          echo "tag=$NEW" >> "$GITHUB_OUTPUT"
+          # Bare version, no leading "v" — matches the repo's tag convention.
           echo "number=${NEW#v}" >> "$GITHUB_OUTPUT"
 
       # Promote the curated "## [Unreleased]" section to a dated version heading
@@ -57,7 +57,7 @@ jobs:
       - name: Publish (dry run)
         if: ${{ github.event.inputs.dry-run == 'true' }}
         run: |
-          echo "DRY RUN — would release ${{ steps.version.outputs.tag }}"
+          echo "DRY RUN — would release ${{ steps.version.outputs.number }}"
           echo '--- release notes ---'
           cat "${{ steps.notes.outputs.file }}"
           npm publish --provenance --dry-run
@@ -75,9 +75,12 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add package.json package-lock.json CHANGELOG.md
-          git commit -m "release: ${{ steps.version.outputs.tag }}"
-          git tag "${{ steps.version.outputs.tag }}"
+          # --no-verify: skip husky/lint-staged on the automated release commit.
+          git commit --no-verify -m "release: ${{ steps.version.outputs.number }}"
+          # Annotated tag so `git push --follow-tags` actually pushes it (it
+          # skips lightweight tags); bare version to match the tag convention.
+          git tag -a "${{ steps.version.outputs.number }}" -m "${{ steps.version.outputs.number }}"
           git push --follow-tags origin main
-          gh release create "${{ steps.version.outputs.tag }}" \
-            --title "${{ steps.version.outputs.tag }}" \
+          gh release create "${{ steps.version.outputs.number }}" \
+            --title "${{ steps.version.outputs.number }}" \
             --notes-file "${{ steps.notes.outputs.file }}"


### PR DESCRIPTION
Follow-up from the 8.0.0 release. The publish to npm succeeded (8.0.0 is live with provenance) but the workflow's final step errored, so the git tag + GitHub release had to be created by hand. Three root causes, all fixed here:

1. **`v` prefix** — the tag/release used `npm version`'s `v8.0.0` output, but every prior tag is bare (`7.1.4`, `7.0.0`, …). Now uses the bare `number` output.
2. **Tag never pushed** — the real failure. `git tag` created a *lightweight* tag, and `git push --follow-tags` only pushes *annotated* tags, so `gh release create` failed with "tag … has not been pushed". Now creates an annotated tag.
3. **Hooks on the release commit** — `npm ci` runs `prepare` (husky), so the automated release commit triggered lint-staged. Added `--no-verify`.

The 8.0.0 tag and GitHub release already exist (created manually); this only affects future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)