### PR TITLE
fix: drop node:util from addContext to restore browser bundling (#425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # mochawesome changelog
 
 ## [Unreleased]
+### Fixed
+- `mochawesome/addContext` no longer imports `node:util`, restoring browser
+  bundling (e.g. Cypress support files built with webpack) that broke in
+  8.0.0 [#425](https://github.com/adamgruber/mochawesome/issues/425).
 
 ## [8.0.0] - 2026-07-30
 ### Breaking

--- a/src/addContext.js
+++ b/src/addContext.js
@@ -1,5 +1,15 @@
 const stringify = require('json-stringify-safe');
-const { styleText } = require('node:util');
+
+// Gray the log prefix without importing `node:util`. `addContext` is bundled
+// for the browser (e.g. Cypress/webpack), and a `node:` builtin anywhere in
+// its require graph breaks bundling (#425). Only emit ANSI codes for a TTY so
+// browsers/CI logs get plain text instead of raw escape sequences.
+/* c8 ignore start */
+const gray = str =>
+  typeof process !== 'undefined' && process.stdout?.isTTY
+    ? `[90m${str}[39m`
+    : str;
+/* c8 ignore stop */
 
 const errorPrefix = 'Error adding context:';
 const ERRORS = {
@@ -27,7 +37,7 @@ function log(msg, level) {
   if (typeof msg === 'object') {
     out = stringify(msg, null, 2);
   }
-  logMethod(`[${styleText('gray', 'mochawesome')}] ${out}\n`);
+  logMethod(`[${gray('mochawesome')}] ${out}\n`);
 }
 /* c8 ignore stop */
 

--- a/test/addContext.test.js
+++ b/test/addContext.test.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 const addContext = require('../src/addContext');
 
 describe('addContext', () => {
@@ -26,8 +28,7 @@ describe('addContext', () => {
 
     activeTest = {
       title: 'sample test',
-      body:
-        'function () {\n    addContext(this, "i\'m in a test");\n    assert(true);\n  }',
+      body: 'function () {\n    addContext(this, "i\'m in a test");\n    assert(true);\n  }',
       async: 0,
       sync: true,
       timedOut: false,
@@ -194,5 +195,16 @@ describe('addContext', () => {
       addContext(testObj, { title: 'context title' });
       test.should.not.have.property('context');
     });
+  });
+
+  // addContext is imported into browser test code (e.g. Cypress support files)
+  // and bundled with webpack, which cannot resolve the `node:` scheme. Guard
+  // against a Node builtin creeping back into its require graph — see #425.
+  it('does not import any node: builtin', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '../src/addContext.js'),
+      'utf8'
+    );
+    src.should.not.match(/require\(['"]node:/);
   });
 });


### PR DESCRIPTION
Fixes #425.

## Problem
8.0.0's chalk→`node:util` migration added `require('node:util')` to `src/addContext.js` (for `styleText`, used only to gray the `[mochawesome]` log prefix). `addContext` is documented for browser test code — e.g. imported in a Cypress support file — which Cypress bundles with webpack 5. Webpack can't resolve the `node:` URI scheme, so the support file fails to compile and every spec aborts:

```
UnhandledSchemeError: Reading from "node:util" is not handled by plugins (Unhandled scheme).
```

7.x had no Node builtins in `addContext`'s require graph.

## Fix
- Remove the `node:util` import. Replace `styleText('gray', …)` with a tiny inline `gray()` helper that emits the ANSI gray escape **only for a TTY** (`typeof process !== 'undefined' && process.stdout?.isTTY`), and plain text otherwise. Keeps the terminal color, adds zero Node builtins, and avoids dumping raw escape codes into a browser console.
  - Note: a lazy `require('node:util')` inside `log()` would **not** fix this — webpack statically analyzes all `require()` calls, so the import must be gone entirely.
- Add a regression test asserting `src/addContext.js` imports no `node:` builtin.
- CHANGELOG entry under `[Unreleased]`.

`utils.js` (reporter-side, Node-only, never bundled for the browser) still uses `node:util` — unchanged.

## Verification
- Full suite passes; parity snapshots unchanged; coverage 100% stmts/lines, 97.43% branches.
- Manually confirmed: non-TTY output is plain `[mochawesome]`; TTY output is gray; `addContext`'s require graph is only `addContext.js` + `json-stringify-safe`.

Suggest releasing as **8.0.1** via the release workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)